### PR TITLE
PSR-2 code cleanup

### DIFF
--- a/app/DepartmentHandler.php
+++ b/app/DepartmentHandler.php
@@ -5,22 +5,22 @@ use GuzzleHttp\Client;
 use XPathSelector\Selector;
 use App\Helpers;
 
-
 // Includes both fetching and parsing functions
 // now combined into one class.
-abstract class DepartmentHandler {
+abstract class DepartmentHandler
+{
 
-	// Fetching-related variables:
-	public $guzzleClient;
+    // Fetching-related variables:
+    public $guzzleClient;
 
-	public $ownerAcronym;
-	public $indexUrl;
+    public $ownerAcronym;
+    public $indexUrl;
 
-	public $activeQuarterPage;
-	public $activeFiscalYear;
-	public $activeFiscalQuarter;
+    public $activeQuarterPage;
+    public $activeFiscalYear;
+    public $activeFiscalQuarter;
 
-	public $totalContractsFetched = 0;
+    public $totalContractsFetched = 0;
 
     /**
      * XPath selector to, from the index page, get the quarter URLs.
@@ -43,552 +43,522 @@ abstract class DepartmentHandler {
      */
     public $quarterMultiPageXpath;
 
-	public $contractContentSubsetXpath;
-	public $contentSplitParameters = [];
+    public $contractContentSubsetXpath;
+    public $contentSplitParameters = [];
 
-	public $multiPage = 0;
-	public $sleepBetweenDownloads = 0;
-
-
-	// Parsing variables:
-	public static $rowParams = [
-	    'uuid' => '',
-	    'vendorName' => '',
-	    'referenceNumber' => '',
-	    'contractDate' => '',
-	    'description' => '',
-	    'extraDescription' => '',
-	    'objectCode' => '',
-	    'contractPeriodStart' => '',
-	    'contractPeriodEnd' => '',
-	    'startYear' => '',
-	    'endYear' => '',
-	    'deliveryDate' => '',
-	    'originalValue' => '',
-	    'contractValue' => '',
-	    'comments' => '',
-	    'ownerAcronym' => '',
-	    'sourceYear' => '',
-	    'sourceQuarter' => '',
-	    'sourceFiscal' => '',
-	    'sourceFilename' => '',
-	    'sourceURL' => '',
-	    'amendedValues' => [],
-	];
+    public $multiPage = 0;
+    public $sleepBetweenDownloads = 0;
 
 
-	public function __construct($detailsArray = []) {
-
-		// Suppress Xpath-Selector warnings (based on HTML5 rather than XML input).
-		// Thanks to
-		// https://stackoverflow.com/a/9149241/756641
-		libxml_use_internal_errors(true);
-
-		if($this->baseUrl) {
-			$this->guzzleClient = new Client(['base_uri' => $this->baseUrl]);
-		}
-		else {
-			$this->guzzleClient = new Client;
-		}
-		
-
-
-
-	}
-
-	// By default, just return the same
-	// Child classes can change this, to eg. add a parent URL
-	public function quarterToContractUrlTransform($contractUrl) {
-		return $contractUrl;
-	}
-
-	// Similar to the above, but for index pages
-	public function indexToQuarterUrlTransform($contractUrl) {
-		return $contractUrl;
-	}
-
-	// In case we want to filter specific URLs out of the list of quarter URLs
-	// Useful for departments (like CBSA) that change their schema halfway through :P 
-	public function filterQuarterUrls($quarterUrls) {
-		return $quarterUrls;
-	}
+    // Parsing variables:
+    public static $rowParams = [
+        'uuid' => '',
+        'vendorName' => '',
+        'referenceNumber' => '',
+        'contractDate' => '',
+        'description' => '',
+        'extraDescription' => '',
+        'objectCode' => '',
+        'contractPeriodStart' => '',
+        'contractPeriodEnd' => '',
+        'startYear' => '',
+        'endYear' => '',
+        'deliveryDate' => '',
+        'originalValue' => '',
+        'contractValue' => '',
+        'comments' => '',
+        'ownerAcronym' => '',
+        'sourceYear' => '',
+        'sourceQuarter' => '',
+        'sourceFiscal' => '',
+        'sourceFilename' => '',
+        'sourceURL' => '',
+        'amendedValues' => [],
+    ];
 
 
-	// Primary function to fetch pages
-	public function fetch() {
+    public function __construct($detailsArray = [])
+    {
 
-		// Run the operation!
-		$startDate = date('Y-m-d H:i:s');
-		echo "Starting " . $this->ownerAcronym . " at ". $startDate . " \n\n";
-		$startTime = microtime(true);
+        // Suppress Xpath-Selector warnings (based on HTML5 rather than XML input).
+        // Thanks to
+        // https://stackoverflow.com/a/9149241/756641
+        libxml_use_internal_errors(true);
 
+        if ($this->baseUrl) {
+            $this->guzzleClient = new Client(['base_uri' => $this->baseUrl]);
+        } else {
+            $this->guzzleClient = new Client;
+        }
+    }
 
-		$indexPage = $this->getPage($this->indexUrl);
+    // By default, just return the same
+    // Child classes can change this, to eg. add a parent URL
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return $contractUrl;
+    }
 
-		$quarterUrls = Helpers::arrayFromHtmlViaXpath($indexPage, $this->indexToQuarterXpath);
+    // Similar to the above, but for index pages
+    public function indexToQuarterUrlTransform($contractUrl)
+    {
+        return $contractUrl;
+    }
 
-		$quarterUrls = $this->filterQuarterUrls($quarterUrls);
-
-		if(env('DEV_TEST_INDEX', 0) == 1) {
-			echo "DEV_TEST_INDEX\n";
-			dd($quarterUrls);
-		}
-
-		$quartersFetched = 0;
-		foreach ($quarterUrls as $url) {
-
-			if(env('FETCH_LIMIT_QUARTERS', 2) && $quartersFetched >= env('FETCH_LIMIT_QUARTERS', 2)) {
-				break;
-			}
-
-			$url = $this->indexToQuarterUrlTransform($url);
-
-			echo $url . "\n";
-
-			// If the quarter pages have server-side pagination, then we need to get the multiple pages that represent that quarter. If there's only one page, then we'll put that as a single item in an array below, to simplify any later steps:
-			$quarterMultiPages = [];
-			if($this->multiPage == 1) {
-
-				$quarterPage = $this->getPage($url);
-
-				// If there aren't multipages, this just returns the original quarter URL back as a single item array:
-				$quarterMultiPages = Helpers::arrayFromHtmlViaXpath($quarterPage, $this->quarterMultiPageXpath);
-
-			}
-			else {
-				$quarterMultiPages = [ $url ];
-			}
+    // In case we want to filter specific URLs out of the list of quarter URLs
+    // Useful for departments (like CBSA) that change their schema halfway through :P
+    public function filterQuarterUrls($quarterUrls)
+    {
+        return $quarterUrls;
+    }
 
 
-			$contractsFetched = 0;
-			// Retrive all the (potentially multiple) pages from the given quarter:
-			foreach($quarterMultiPages as $url) {
-				echo "D: " . $url . "\n";
+    // Primary function to fetch pages
+    public function fetch()
+    {
 
-				$this->activeQuarterPage = $url;
-
-				$quarterPage = $this->getPage($url);
-
-				// Clear it first just in case
-				$this->activeFiscalYear = '';
-				$this->activeFiscalQuarter = '';
-
-				if(method_exists($this, 'fiscalYearFromQuarterPage')) {
-					$this->activeFiscalYear = $this->fiscalYearFromQuarterPage($quarterPage, $url);
-				}
-				if(method_exists($this, 'fiscalQuarterFromQuarterPage')) {
-					$this->activeFiscalQuarter = $this->fiscalQuarterFromQuarterPage($quarterPage, $url);
-				}
+        // Run the operation!
+        $startDate = date('Y-m-d H:i:s');
+        echo "Starting " . $this->ownerAcronym . " at ". $startDate . " \n\n";
+        $startTime = microtime(true);
 
 
-				$contractUrls = Helpers::arrayFromHtmlViaXpath($quarterPage, $this->quarterToContractXpath);
+        $indexPage = $this->getPage($this->indexUrl);
+
+        $quarterUrls = Helpers::arrayFromHtmlViaXpath($indexPage, $this->indexToQuarterXpath);
+
+        $quarterUrls = $this->filterQuarterUrls($quarterUrls);
+
+        if (env('DEV_TEST_INDEX', 0) == 1) {
+            echo "DEV_TEST_INDEX\n";
+            dd($quarterUrls);
+        }
+
+        $quartersFetched = 0;
+        foreach ($quarterUrls as $url) {
+            if (env('FETCH_LIMIT_QUARTERS', 2) && $quartersFetched >= env('FETCH_LIMIT_QUARTERS', 2)) {
+                break;
+            }
+
+            $url = $this->indexToQuarterUrlTransform($url);
+
+            echo $url . "\n";
+
+            // If the quarter pages have server-side pagination, then we need to get the multiple pages that represent that quarter. If there's only one page, then we'll put that as a single item in an array below, to simplify any later steps:
+            $quarterMultiPages = [];
+            if ($this->multiPage == 1) {
+                $quarterPage = $this->getPage($url);
+
+                // If there aren't multipages, this just returns the original quarter URL back as a single item array:
+                $quarterMultiPages = Helpers::arrayFromHtmlViaXpath($quarterPage, $this->quarterMultiPageXpath);
+            } else {
+                $quarterMultiPages = [ $url ];
+            }
 
 
-				if(env('DEV_TEST_QUARTER', 0) == 1) {
-					echo "DEV_TEST_QUARTER\n";
-					dd($contractUrls);
-				}
+            $contractsFetched = 0;
+            // Retrive all the (potentially multiple) pages from the given quarter:
+            foreach ($quarterMultiPages as $url) {
+                echo "D: " . $url . "\n";
 
-				foreach($contractUrls as $contractUrl) {
+                $this->activeQuarterPage = $url;
 
-					if(env('FETCH_LIMIT_CONTRACTS_PER_QUARTER', 2) && $contractsFetched >= env('FETCH_LIMIT_CONTRACTS_PER_QUARTER', 2)) {
-						break;
-					}
+                $quarterPage = $this->getPage($url);
 
-					$contractUrl = $this->quarterToContractUrlTransform($contractUrl);
+                // Clear it first just in case
+                $this->activeFiscalYear = '';
+                $this->activeFiscalQuarter = '';
 
-					echo "   " . $contractUrl . "\n";
+                if (method_exists($this, 'fiscalYearFromQuarterPage')) {
+                    $this->activeFiscalYear = $this->fiscalYearFromQuarterPage($quarterPage, $url);
+                }
+                if (method_exists($this, 'fiscalQuarterFromQuarterPage')) {
+                    $this->activeFiscalQuarter = $this->fiscalQuarterFromQuarterPage($quarterPage, $url);
+                }
 
-					$this->downloadPage($contractUrl, $this->ownerAcronym);
-					$this->saveMetadata($contractUrl);
 
-					$this->totalContractsFetched++;
-					$contractsFetched++;
-				}
+                $contractUrls = Helpers::arrayFromHtmlViaXpath($quarterPage, $this->quarterToContractXpath);
 
-			}
 
-			echo "$contractsFetched pages downloaded for this quarter.\n\n";
+                if (env('DEV_TEST_QUARTER', 0) == 1) {
+                    echo "DEV_TEST_QUARTER\n";
+                    dd($contractUrls);
+                }
 
-			$quartersFetched++;
-		}
-		// echo $indexPage;
+                foreach ($contractUrls as $contractUrl) {
+                    if (env('FETCH_LIMIT_CONTRACTS_PER_QUARTER', 2) && $contractsFetched >= env('FETCH_LIMIT_CONTRACTS_PER_QUARTER', 2)) {
+                        break;
+                    }
 
-	}
+                    $contractUrl = $this->quarterToContractUrlTransform($contractUrl);
+
+                    echo "   " . $contractUrl . "\n";
+
+                    $this->downloadPage($contractUrl, $this->ownerAcronym);
+                    $this->saveMetadata($contractUrl);
+
+                    $this->totalContractsFetched++;
+                    $contractsFetched++;
+                }
+            }
+
+            echo "$contractsFetched pages downloaded for this quarter.\n\n";
+
+            $quartersFetched++;
+        }
+        // echo $indexPage;
+    }
 
 
 
     // Get a page using the Guzzle library
-	// No longer a static function since we're reusing the client object between requests.
-	// Ignores SSL verification per http://stackoverflow.com/a/32707976/756641
-	public function getPage($url) {
-		$response = $this->guzzleClient->request('GET', $url,
-			[
-				'verify' => false,
-			]);
-		return $response->getBody();
-	}
+    // No longer a static function since we're reusing the client object between requests.
+    // Ignores SSL verification per http://stackoverflow.com/a/32707976/756641
+    public function getPage($url)
+    {
+        $response = $this->guzzleClient->request(
+            'GET',
+            $url,
+            [
+                'verify' => false,
+            ]
+        );
+        return $response->getBody();
+    }
 
-	public function removeSessionIdsFromUrl($url) {
-		// Can be overridden on a per-department basis:
-		return $url;
-	}
+    public function removeSessionIdsFromUrl($url)
+    {
+        // Can be overridden on a per-department basis:
+        return $url;
+    }
 
     // Generic page download function
-	// Downloads the requested URL and saves it to the specified directory
-	// If the same URL has already been downloaded, it avoids re-downloading it again.
-	// This makes it easier to stop and re-start the script without having to go from the very beginning again.
-	public function downloadPage($url, $subdirectory = '') {
+    // Downloads the requested URL and saves it to the specified directory
+    // If the same URL has already been downloaded, it avoids re-downloading it again.
+    // This makes it easier to stop and re-start the script without having to go from the very beginning again.
+    public function downloadPage($url, $subdirectory = '')
+    {
 
-		$url = Helpers::cleanupIncomingUrl($url);
+        $url = Helpers::cleanupIncomingUrl($url);
 
-		$filename = Helpers::urlToFilename($this->removeSessionIdsFromUrl($url));
+        $filename = Helpers::urlToFilename($this->removeSessionIdsFromUrl($url));
 
-		$directoryPath = storage_path() . '/' . env('FETCH_RAW_HTML_FOLDER', 'raw-data');
+        $directoryPath = storage_path() . '/' . env('FETCH_RAW_HTML_FOLDER', 'raw-data');
 
-		if($subdirectory) {
-			$directoryPath .= '/' . $subdirectory;
-		}
+        if ($subdirectory) {
+            $directoryPath .= '/' . $subdirectory;
+        }
 
-		// If the folder doesn't exist yet, create it:
-		// Thanks to http://stackoverflow.com/a/15075269/756641
-		if(! is_dir($directoryPath)) {
-			mkdir($directoryPath, 0755, true);
-		}
+        // If the folder doesn't exist yet, create it:
+        // Thanks to http://stackoverflow.com/a/15075269/756641
+        if (! is_dir($directoryPath)) {
+            mkdir($directoryPath, 0755, true);
+        }
 
-		// If that particular page has already been downloaded,
-		// don't download it again.
-		// That lets us re-start the script without starting from the very beginning again.
-		if(file_exists($directoryPath . '/' . $filename) == false || env('FETCH_REDOWNLOAD_EXISTING_FILES', 1)) {
+        // If that particular page has already been downloaded,
+        // don't download it again.
+        // That lets us re-start the script without starting from the very beginning again.
+        if (file_exists($directoryPath . '/' . $filename) == false || env('FETCH_REDOWNLOAD_EXISTING_FILES', 1)) {
+            // Download the page in question:
+            $pageSource = $this->getPage($url);
 
-			// Download the page in question:
-			$pageSource = $this->getPage($url);
+            // echo "ENCODING IS: ";
+            // $encoding = mb_detect_encoding($pageSource, mb_detect_order(), 1);
+            // echo $encoding . "\n";
 
-			// echo "ENCODING IS: ";
-			// $encoding = mb_detect_encoding($pageSource, mb_detect_order(), 1);
-			// echo $encoding . "\n";
+            if ($pageSource) {
+                if ($this->contentSplitParameters) {
+                    $split = explode($this->contentSplitParameters['startSplit'], $pageSource);
+                    $pageSource = explode($this->contentSplitParameters['endSplit'], $split[1])[0];
+                }
 
-			if($pageSource) {
+                if ($this->contractContentSubsetXpath) {
+                    $xs = Selector::loadHTML($pageSource);
+                    $pageSource = $xs->find($this->contractContentSubsetXpath)->innerHTML();
+                }
 
-				if($this->contentSplitParameters) {
+                // Store it to a local location:
+                file_put_contents($directoryPath . '/' . $filename, $pageSource);
 
-					$split = explode($this->contentSplitParameters['startSplit'], $pageSource);
-					$pageSource = explode($this->contentSplitParameters['endSplit'], $split[1])[0];
+                // Optionally sleep for a certain amount of time (eg. 0.1 seconds) in between fetches to avoid angry sysadmins:
+                if (env('FETCH_SLEEP_BETWEEN_DOWNLOADS', 0)) {
+                    sleep(env('FETCH_SLEEP_BETWEEN_DOWNLOADS', 0));
+                }
 
-				}
+                // This can now be configured per-department
+                // The two are cumulative (eg. you could have a system-wide sleep configuration, and a department-specific, and it'll sleep for both durations.)
+                if ($this->sleepBetweenDownloads) {
+                    sleep($this->sleepBetweenDownloads);
+                }
+            }
 
-				if($this->contractContentSubsetXpath) {
+            
+            
+            return true;
+        } else {
+            $this->totalAlreadyDownloaded += 1;
+            return false;
+        }
+    }
 
-					$xs = Selector::loadHTML($pageSource);
-					$pageSource = $xs->find($this->contractContentSubsetXpath)->innerHTML(); 
+    public function saveMetadata($url)
+    {
 
-				}
+        // Only save metadata if we have anything useful:
+        if (! $this->activeFiscalYear) {
+            return false;
+        }
 
-				// Store it to a local location:
-				file_put_contents($directoryPath . '/' . $filename, $pageSource);
-
-				// Optionally sleep for a certain amount of time (eg. 0.1 seconds) in between fetches to avoid angry sysadmins:
-				if(env('FETCH_SLEEP_BETWEEN_DOWNLOADS', 0)) {
-					sleep(env('FETCH_SLEEP_BETWEEN_DOWNLOADS', 0));
-				}
-
-				// This can now be configured per-department
-				// The two are cumulative (eg. you could have a system-wide sleep configuration, and a department-specific, and it'll sleep for both durations.)
-				if($this->sleepBetweenDownloads) {
-					sleep($this->sleepBetweenDownloads);
-				}
-
-			}
-
-			
-			
-			return true;
-
-		}
-		else {
-			$this->totalAlreadyDownloaded += 1;
-			return false;
-		}
-
-
-	}
-
-	public function saveMetadata($url) {
-
-		// Only save metadata if we have anything useful:
-		if(! $this->activeFiscalYear) {
-			return false;
-		}
-
-		$filename = Helpers::urlToFilename($this->removeSessionIdsFromUrl($url), '.json');
-		$directoryPath = storage_path() . '/' . env('FETCH_METADATA_FOLDER', 'metadata') . '/' . $this->ownerAcronym;
+        $filename = Helpers::urlToFilename($this->removeSessionIdsFromUrl($url), '.json');
+        $directoryPath = storage_path() . '/' . env('FETCH_METADATA_FOLDER', 'metadata') . '/' . $this->ownerAcronym;
 
 
-		// If the folder doesn't exist yet, create it:
-		// Thanks to http://stackoverflow.com/a/15075269/756641
-		if(! is_dir($directoryPath)) {
-		    mkdir($directoryPath, 0755, true);
-		}
+        // If the folder doesn't exist yet, create it:
+        // Thanks to http://stackoverflow.com/a/15075269/756641
+        if (! is_dir($directoryPath)) {
+            mkdir($directoryPath, 0755, true);
+        }
 
-		$output = [
-			'sourceURL' => $this->removeSessionIdsFromUrl($url),
-			'sourceYear' => intval($this->activeFiscalYear),
-			'sourceQuarter' => intval($this->activeFiscalQuarter),
-		];
+        $output = [
+            'sourceURL' => $this->removeSessionIdsFromUrl($url),
+            'sourceYear' => intval($this->activeFiscalYear),
+            'sourceQuarter' => intval($this->activeFiscalQuarter),
+        ];
 
-		if(file_put_contents($directoryPath . '/' . $filename, json_encode($output, JSON_PRETTY_PRINT))) {
-			return true;
-		}
+        if (file_put_contents($directoryPath . '/' . $filename, json_encode($output, JSON_PRETTY_PRINT))) {
+            return true;
+        }
 
-		return false;
-
-	}
+        return false;
+    }
 
 
     // Parsing functions:
 
-    public static function cleanParsedArray(&$values) {
+    public static function cleanParsedArray(&$values)
+    {
 
-	    $values['startYear'] = Helpers::yearFromDate($values['contractPeriodStart']);
-	    $values['endYear'] = Helpers::yearFromDate($values['contractPeriodEnd']);
+        $values['startYear'] = Helpers::yearFromDate($values['contractPeriodStart']);
+        $values['endYear'] = Helpers::yearFromDate($values['contractPeriodEnd']);
 
-	    $values['originalValue'] = Helpers::cleanupContractValue($values['originalValue']);
-	    $values['contractValue'] = Helpers::cleanupContractValue($values['contractValue']);
+        $values['originalValue'] = Helpers::cleanupContractValue($values['originalValue']);
+        $values['contractValue'] = Helpers::cleanupContractValue($values['contractValue']);
 
-	    if(! $values['contractValue']) {
-	        $values['contractValue'] = $values['originalValue'];
-	    }
+        if (! $values['contractValue']) {
+            $values['contractValue'] = $values['originalValue'];
+        }
 
-	    if($values['originalValue'] == 0) {
-	        $values['originalValue'] = $values['contractValue'];
-	    }
+        if ($values['originalValue'] == 0) {
+            $values['originalValue'] = $values['contractValue'];
+        }
 
-	    // Check for error-y non-unicode characters
-	    $values['referenceNumber'] = Helpers::cleanText($values['referenceNumber']);
-	    $values['vendorName'] = Helpers::cleanText($values['vendorName']);
-	    $values['comments'] = Helpers::cleanText($values['comments']);
-	    $values['description'] = Helpers::cleanText($values['description']);
-	    $values['extraDescription'] = Helpers::cleanText($values['extraDescription']);
+        // Check for error-y non-unicode characters
+        $values['referenceNumber'] = Helpers::cleanText($values['referenceNumber']);
+        $values['vendorName'] = Helpers::cleanText($values['vendorName']);
+        $values['comments'] = Helpers::cleanText($values['comments']);
+        $values['description'] = Helpers::cleanText($values['description']);
+        $values['extraDescription'] = Helpers::cleanText($values['extraDescription']);
+    }
 
+    public static function generateAdditionalMetadata(&$values)
+    {
 
-	}
+        if ($values['sourceYear'] && $values['sourceQuarter']) {
+            // Generate a more traditional "20162017-Q3"
+            $values['sourceFiscal'] = $values['sourceYear'] . (substr($values['sourceYear'], 2, 2) + 1) . '-Q' . $values['sourceQuarter'];
+        }
+    }
 
-	public static function generateAdditionalMetadata(&$values) {
 
-	    if($values['sourceYear'] && $values['sourceQuarter']) {
+    // Primary function to parse pages:
+    public function parse()
+    {
 
-	        // Generate a more traditional "20162017-Q3"
-	        $values['sourceFiscal'] = $values['sourceYear'] . (substr($values['sourceYear'], 2, 2) + 1) . '-Q' . $values['sourceQuarter'];
+        $startDate = date('Y-m-d H:i:s');
+        echo "Starting to parse " . $this->ownerAcronym . " at ". $startDate . " \n";
 
-	    }
+        $sourceDirectory = Helpers::getSourceDirectory($this->ownerAcronym);
 
-	}
+        if (env('PARSE_CLEAN_VENDOR_NAMES', 1) == 1) {
+            $vendorData = new VendorData;
+        } else {
+            $vendorData = null;
+        }
 
+        // Output directory:
+        $directoryPath = storage_path() . '/' . env('PARSE_JSON_OUTPUT_FOLDER', 'generated-data') . '/' . $this->ownerAcronym;
 
-	// Primary function to parse pages:
-	public function parse() {
+        // If the folder doesn't exist yet, create it:
+        // Thanks to http://stackoverflow.com/a/15075269/756641
+        if (! is_dir($directoryPath)) {
+            mkdir($directoryPath, 0755, true);
+        }
 
-		$startDate = date('Y-m-d H:i:s');
-		echo "Starting to parse " . $this->ownerAcronym . " at ". $startDate . " \n";
 
-	    $sourceDirectory = Helpers::getSourceDirectory($this->ownerAcronym);
+        $validFiles = [];
+        $files = array_diff(scandir($sourceDirectory), ['..', '.']);
 
-	    if(env('PARSE_CLEAN_VENDOR_NAMES', 1) == 1) {
-	    	$vendorData = new VendorData;
-	    }
-	    else {
-	    	$vendorData = null;
-	    }
+        foreach ($files as $file) {
+            // Check if it ends with .html
+            $suffix = '.html';
+            if (substr_compare($file, $suffix, -strlen($suffix)) === 0) {
+                $validFiles[] = $file;
+            }
+        }
 
-	    // Output directory:
-	    $directoryPath = storage_path() . '/' . env('PARSE_JSON_OUTPUT_FOLDER', 'generated-data') . '/' . $this->ownerAcronym;
+        $filesParsed = 0;
+        foreach ($validFiles as $file) {
+            if (env('PARSE_LIMIT_FILES', 2) && $filesParsed >= env('PARSE_LIMIT_FILES', 2)) {
+                break;
+            }
 
-	    // If the folder doesn't exist yet, create it:
-	    // Thanks to http://stackoverflow.com/a/15075269/756641
-	    if(! is_dir($directoryPath)) {
-	        mkdir($directoryPath, 0755, true);
-	    }
+            // echo "$file\n";
 
+            $filehash = explode('.', $file)[0];
 
-	    $validFiles = [];
-	    $files = array_diff(scandir($sourceDirectory), ['..', '.']);
+            // Retrieve the values from the department-specific file parser
+            // And merge these with the default values
+            // Just to guarantee that all the array keys are around:
+            $fileValues = array_merge(self::$rowParams, $this->parseFile($file));
 
-	    foreach($files as $file) {
-	        // Check if it ends with .html
-	        $suffix = '.html';
-	        if(substr_compare( $file, $suffix, -strlen( $suffix )) === 0) {
-	            $validFiles[] = $file;
-	        }
-	    }
+            $metadata = $this->getMetadata($file);
 
-	    $filesParsed = 0;
-	    foreach($validFiles as $file) {
-	        if(env('PARSE_LIMIT_FILES', 2) && $filesParsed >= env('PARSE_LIMIT_FILES', 2)) {
-	            break;
-	        }
+            if ($fileValues) {
+                self::cleanParsedArray($fileValues);
+                // var_dump($fileValues);
 
-	        // echo "$file\n";
+                $fileValues = array_merge($fileValues, $metadata);
 
-	        $filehash = explode('.', $file)[0];
+                self::generateAdditionalMetadata($fileValues);
 
-	        // Retrieve the values from the department-specific file parser
-	        // And merge these with the default values
-	        // Just to guarantee that all the array keys are around:
-	        $fileValues = array_merge(self::$rowParams, $this->parseFile($file));
+                $fileValues['ownerAcronym'] = $this->ownerAcronym;
 
-	        $metadata = $this->getMetadata($file);
+                $fileValues['objectCode'] = Helpers::getObjectCodeFromDescription($fileValues['description']);
 
-	        if($fileValues) {
+                // Useful for troubleshooting:
+                $fileValues['sourceFilename'] = $this->ownerAcronym . '/' . $file;
 
-	            self::cleanParsedArray($fileValues);
-	            // var_dump($fileValues);
+                // A lot of DND's entries are missing reference numbers:
+                if (! $fileValues['referenceNumber']) {
+                    echo "Warning: no reference number.\n";
 
-	            $fileValues = array_merge($fileValues, $metadata);
+                    $fileValues['referenceNumber'] = $filehash;
+                }
 
-	            self::generateAdditionalMetadata($fileValues);
+                // Final check for missing values, etc.
+                if (env('PARSE_CLEAN_CONTRACT_VALUES', 1) == 1) {
+                    if (env('PARSE_CLEAN_VENDOR_NAMES', 1) == 1) {
+                        Helpers::checkContractValues($fileValues, $vendorData);
+                    } else {
+                        Helpers::checkContractValues($fileValues);
+                    }
+                }
+                
 
-	            $fileValues['ownerAcronym'] = $this->ownerAcronym;
+                // TODO - update this to match the schema discussed at 2017-03-28's Civic Tech!
+                $fileValues['uuid'] = $this->ownerAcronym . '-' . $fileValues['referenceNumber'];
 
-	            $fileValues['objectCode'] = Helpers::getObjectCodeFromDescription($fileValues['description']);
+                if (file_put_contents($directoryPath . '/' . $filehash . '.json', json_encode($fileValues, JSON_PRETTY_PRINT))) {
+                    // echo "...saved.\n";
+                } else {
+                    echo "...failed to save JSON output for $file.\n";
+                }
+            } else {
+                echo "Error: could not parse data for $file\n";
+            }
 
-	            // Useful for troubleshooting:
-	            $fileValues['sourceFilename'] = $this->ownerAcronym . '/' . $file;
 
-	            // A lot of DND's entries are missing reference numbers:
-	            if(! $fileValues['referenceNumber']) {
-	                echo "Warning: no reference number.\n";
 
-	                $fileValues['referenceNumber'] = $filehash;
+            $filesParsed++;
+        }
+        // var_dump($validFiles);
 
-	            }
+        echo "...started " . $this->ownerAcronym . " at " . $startDate . "\n";
+        echo "Finished parsing $filesParsed files at ". date('Y-m-d H:i:s') . " \n\n";
+    }
 
-	            // Final check for missing values, etc.
-	            if(env('PARSE_CLEAN_CONTRACT_VALUES', 1) == 1) {
-	            	if(env('PARSE_CLEAN_VENDOR_NAMES', 1) == 1) {
-	            		Helpers::checkContractValues($fileValues, $vendorData);
-	            	}
-	            	else {
-	            		Helpers::checkContractValues($fileValues);
-	            	}
-	            }
-	            
+    public function getMetadata($htmlFilename)
+    {
 
-	            // TODO - update this to match the schema discussed at 2017-03-28's Civic Tech!
-	            $fileValues['uuid'] = $this->ownerAcronym . '-' . $fileValues['referenceNumber'];
+        $filename = str_replace('.html', '.json', $htmlFilename);
 
-	            if(file_put_contents($directoryPath . '/' . $filehash . '.json', json_encode($fileValues, JSON_PRETTY_PRINT))) {
-	                // echo "...saved.\n";
-	            }
-	            else {
+        $filepath = Helpers::getMetadataDirectory($this->ownerAcronym) . '/' . $filename;
 
-	            	echo "...failed to save JSON output for $file.\n";
+        if (file_exists($filepath)) {
+            $source = file_get_contents($filepath);
+            $metadata = json_decode($source, 1);
 
-	            }
+            if (is_array($metadata)) {
+                return $metadata;
+            }
+        }
 
-	        }
-	        else {
-	            echo "Error: could not parse data for $file\n";
-	        }
+        return [];
+    }
 
+    public function parseFile($filename)
+    {
 
+        $acronym = $this->ownerAcronym;
 
-	        $filesParsed++;
+        $source = file_get_contents(Helpers::getSourceDirectory($this->ownerAcronym) . '/' . $filename);
 
-	    }
-	    // var_dump($validFiles);
+        $source = Helpers::initialSourceTransform($source, $acronym);
 
-	    echo "...started " . $this->ownerAcronym . " at " . $startDate . "\n";
-	    echo "Finished parsing $filesParsed files at ". date('Y-m-d H:i:s') . " \n\n";
+        // return call_user_func( array( 'App\\DepartmentHandlers\\' . ucfirst($acronym) . 'Handler', 'parseHtml' ), $source );
 
-	}
+        return $this->parseHtml($source);
+    }
 
-	public function getMetadata($htmlFilename) {
+    public static function getDepartments()
+    {
 
-	    $filename = str_replace('.html', '.json', $htmlFilename);
+        $output = [];
+        $sourceDirectory = storage_path() . '/' . env('FETCH_RAW_HTML_FOLDER', 'raw-data');
 
-	    $filepath = Helpers::getMetadataDirectory($this->ownerAcronym) . '/' . $filename;
 
-	    if(file_exists($filepath)) {
+        $departments = array_diff(scandir($sourceDirectory), ['..', '.']);
 
-	        $source = file_get_contents($filepath);
-	        $metadata = json_decode($source, 1);
+        // Make sure that these are really directories
+        // This could probably done with some more elegant array map function
+        foreach ($departments as $department) {
+            if (is_dir($sourceDirectory . $department)) {
+                $output[] = $department;
+            }
+        }
 
-	        if(is_array($metadata)) {
+        return $output;
+    }
 
-	            return $metadata;
-	        }
+    public static function parseAllDepartments()
+    {
 
-	    }
+        // Run the operation!
+        $startTime = microtime(true);
 
-	    return [];
+        // Question of the day is... how big can PHP arrays get?
+        $output = [];
 
-	}
+        $departments = DepartmentParser::getDepartments();
 
-	public function parseFile($filename) {
+        $departmentsParsed = 0;
+        foreach ($departments as $acronym) {
+            // if(in_array($acronym, $configuration['departmentsToSkip'])) {
+            //     echo "Skipping " . $acronym . "\n";
+            //     continue;
+            // }
 
-	    $acronym = $this->ownerAcronym;
+            if (env('PARSE_LIMIT_DEPARTMENTS', 0) && $departmentsParsed >= env('PARSE_LIMIT_DEPARTMENTS', 0)) {
+                break;
+            }
 
-	    $source = file_get_contents(Helpers::getSourceDirectory($this->ownerAcronym) . '/' . $filename);
+            $department = new DepartmentParser($acronym);
 
-	    $source = Helpers::initialSourceTransform($source, $acronym);
+            $department->parse();
 
-	    // return call_user_func( array( 'App\\DepartmentHandlers\\' . ucfirst($acronym) . 'Handler', 'parseHtml' ), $source );
-
-	    return $this->parseHtml($source);
-
-	}
-
-    public static function getDepartments() {
-
-	    $output = [];
-	    $sourceDirectory = storage_path() . '/' . env('FETCH_RAW_HTML_FOLDER', 'raw-data');
-
-
-	    $departments = array_diff(scandir($sourceDirectory), ['..', '.']);
-
-	    // Make sure that these are really directories
-	    // This could probably done with some more elegant array map function
-	    foreach($departments as $department) {
-	        if(is_dir($sourceDirectory . $department)) {
-	            $output[] = $department;
-	        }
-	    }
-
-	    return $output;
-
-	}
-
-	public static function parseAllDepartments() {
-
-	    // Run the operation!
-	    $startTime = microtime(true);
-
-	    // Question of the day is... how big can PHP arrays get?
-	    $output = [];
-
-	    $departments = DepartmentParser::getDepartments();
-
-	    $departmentsParsed = 0;
-	    foreach($departments as $acronym) {
-
-	        // if(in_array($acronym, $configuration['departmentsToSkip'])) {
-	        //     echo "Skipping " . $acronym . "\n";
-	        //     continue;
-	        // }
-
-	        if(env('PARSE_LIMIT_DEPARTMENTS', 0) && $departmentsParsed >= env('PARSE_LIMIT_DEPARTMENTS', 0)) {
-	            break;
-	        }
-
-	        $department = new DepartmentParser($acronym);
-
-	        $department->parse();
-
-	        $departmentsParsed++;
-
-	    }
-
-	}
+            $departmentsParsed++;
+        }
+    }
 
     /**
      * Parse the HTML of a given contract, converting the data to
@@ -598,6 +568,5 @@ abstract class DepartmentHandler {
      *
      * @return array  The extracted contract data.
      */
-	abstract public function parseHtml( $source );
-
+    abstract public function parseHtml($source);
 }

--- a/app/DepartmentHandlers/AgrHandler.php
+++ b/app/DepartmentHandlers/AgrHandler.php
@@ -4,51 +4,51 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class AgrHandler extends DepartmentHandler {
+class AgrHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.agr.gc.ca/eng/about-us/planning-and-reporting/proactive-disclosure/disclosure-of-contracts-over-10000/?id=1353352471596';
-	public $baseUrl = 'http://www.agr.gc.ca/';
-	public $ownerAcronym = 'agr';
+    public $indexUrl = 'http://www.agr.gc.ca/eng/about-us/planning-and-reporting/proactive-disclosure/disclosure-of-contracts-over-10000/?id=1353352471596';
+    public $baseUrl = 'http://www.agr.gc.ca/';
+    public $ownerAcronym = 'agr';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	/*
+    /*
 	public function quarterToContractUrlTransform($contractUrl) {
 		return "http://www.ec.gc.ca/contracts-contrats/" . $contractUrl;
 	}
 	*/
 
-	/*
+    /*
 	public function indexToQuarterUrlTransform($url) {
 		return "http://www.ec.gc.ca/contracts-contrats/" . $url;
 	}
 	*/
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//table//caption", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//table//caption", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//table//caption", '/([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//table//caption", '/([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
-
-	public function parseHtml($html) {
-
-		return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ');
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ');
+    }
 }

--- a/app/DepartmentHandlers/CbsaHandler.php
+++ b/app/DepartmentHandlers/CbsaHandler.php
@@ -5,134 +5,133 @@ use App\DepartmentHandler;
 use App\Helpers;
 use XPathSelector\Selector;
 
-class CbsaHandler extends DepartmentHandler {
+class CbsaHandler extends DepartmentHandler
+{
 
-	
-	public $indexUrl = 'http://www.cbsa-asfc.gc.ca/pd-dp/contracts-contrats/reports-rapports-eng.html';
-	public $baseUrl = 'http://www.cbsa-asfc.gc.ca/';
-	public $ownerAcronym = 'cbsa';
+    
+    public $indexUrl = 'http://www.cbsa-asfc.gc.ca/pd-dp/contracts-contrats/reports-rapports-eng.html';
+    public $baseUrl = 'http://www.cbsa-asfc.gc.ca/';
+    public $ownerAcronym = 'cbsa';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main[@class='container']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main[@class='container']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//table[@id='pdcon-table']//td//a/@href";
-
-
-	public $contractContentSubsetXpath = "//div[@id='wb-main-in']";
-
-	// Since the a href tags on the quarter pages just return a path-relative URL, use this to prepend the rest of the URL path
-	public function quarterToContractUrlTransform($contractUrl) {
-		echo "Q: " . $this->activeQuarterPage . "\n";
-
-		$urlArray = explode('/', $this->activeQuarterPage);
-		array_pop($urlArray);
-
-		$urlString = implode('/',$urlArray).'/';
-
-		return $urlString.$contractUrl;
-
-	}
-
-	// Ignore the latest quarter that uses "open.canada.ca" as a link instead.
-	// We'll need to retrieve those from the actual dataset.
-	public function filterQuarterUrls($quarterUrls) {
-
-		// Remove the new entries with "open.canada.ca"
-		$quarterUrls = array_filter($quarterUrls, function($url) {
-			if(strpos($url, 'open.canada.ca') !== false) {
-				return false;
-			}
-			return true;
-		});
-
-		return $quarterUrls;
-	}
-
-	public function fiscalYearFromQuarterPage($quarterHtml) {
-
-		// <h1 id="wb-cont">ARCHIVED - 2015-2016, Q3 (October - December 2015)</h1>
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
-
-	}
-
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
-
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/Q([0-9])/');
-
-	}
+    public $quarterToContractXpath = "//table[@id='pdcon-table']//td//a/@href";
 
 
-	
+    public $contractContentSubsetXpath = "//div[@id='wb-main-in']";
 
-	public function parseHtml($html) {
+    // Since the a href tags on the quarter pages just return a path-relative URL, use this to prepend the rest of the URL path
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        echo "Q: " . $this->activeQuarterPage . "\n";
 
-		$values = [];
-		$keyToLabel = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Additional description:',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => '',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
+        $urlArray = explode('/', $this->activeQuarterPage);
+        array_pop($urlArray);
 
-		$cleanKeys = [];
-		foreach($keyToLabel as $key => $label) {
-			$cleanKeys[$key] = Helpers::cleanLabelText($label);
-		}
+        $urlString = implode('/', $urlArray).'/';
 
-		$labelToKey = array_flip($cleanKeys);
+        return $urlString.$contractUrl;
+    }
 
-		$xs = Selector::loadHTML($html);
+    // Ignore the latest quarter that uses "open.canada.ca" as a link instead.
+    // We'll need to retrieve those from the actual dataset.
+    public function filterQuarterUrls($quarterUrls)
+    {
 
-		// Extracts the keys (from the <th> tags) in order
-		$keyXpath = "//table[@class='contractDetail span-6']//th";
-		$keyNodes = $xs->findAll($keyXpath)->map(function ($node, $index) {
-			return (string)$node;
-		});
+        // Remove the new entries with "open.canada.ca"
+        $quarterUrls = array_filter($quarterUrls, function ($url) {
+            if (strpos($url, 'open.canada.ca') !== false) {
+                return false;
+            }
+            return true;
+        });
 
-		// Extracts the values (from the <td> tags) in hopefully the same order:
-		$valueXpath = "//table[@class='contractDetail span-6']//td";
-		$valueNodes = $xs->findAll($valueXpath)->map(function ($node, $index) {
-			return (string)$node;
-		});
+        return $quarterUrls;
+    }
 
-		$keys = [];
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// var_dump($keyNodes);
-		// var_dump($valueNodes);
+        // <h1 id="wb-cont">ARCHIVED - 2015-2016, Q3 (October - December 2015)</h1>
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+    }
 
-		foreach($keyNodes as $index => $keyNode) {
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-			$keyNode = Helpers::cleanLabelText($keyNode);
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/Q([0-9])/');
+    }
 
-			if(isset($labelToKey[$keyNode]) && $labelToKey[$keyNode]) {
-				$values[$labelToKey[$keyNode]] = Helpers::cleanHtmlValue($valueNodes[$index]);
-			}
 
-		}
+    
 
-		// var_dump($values);
-		// exit();
+    public function parseHtml($html)
+    {
 
-		// Change the "to" range into start and end values:
-		if(isset($values['contractPeriodRange']) && $values['contractPeriodRange']) {
-			$split = explode(' to ', $values['contractPeriodRange']);
-			$values['contractPeriodStart'] = trim($split[0]);
-			$values['contractPeriodEnd'] = trim($split[1]);
-		}
+        $values = [];
+        $keyToLabel = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Additional description:',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => '',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-		// var_dump($values);
-		return $values;
+        $cleanKeys = [];
+        foreach ($keyToLabel as $key => $label) {
+            $cleanKeys[$key] = Helpers::cleanLabelText($label);
+        }
 
-	}
+        $labelToKey = array_flip($cleanKeys);
 
+        $xs = Selector::loadHTML($html);
+
+        // Extracts the keys (from the <th> tags) in order
+        $keyXpath = "//table[@class='contractDetail span-6']//th";
+        $keyNodes = $xs->findAll($keyXpath)->map(function ($node, $index) {
+            return (string)$node;
+        });
+
+        // Extracts the values (from the <td> tags) in hopefully the same order:
+        $valueXpath = "//table[@class='contractDetail span-6']//td";
+        $valueNodes = $xs->findAll($valueXpath)->map(function ($node, $index) {
+            return (string)$node;
+        });
+
+        $keys = [];
+
+        // var_dump($keyNodes);
+        // var_dump($valueNodes);
+
+        foreach ($keyNodes as $index => $keyNode) {
+            $keyNode = Helpers::cleanLabelText($keyNode);
+
+            if (isset($labelToKey[$keyNode]) && $labelToKey[$keyNode]) {
+                $values[$labelToKey[$keyNode]] = Helpers::cleanHtmlValue($valueNodes[$index]);
+            }
+        }
+
+        // var_dump($values);
+        // exit();
+
+        // Change the "to" range into start and end values:
+        if (isset($values['contractPeriodRange']) && $values['contractPeriodRange']) {
+            $split = explode(' to ', $values['contractPeriodRange']);
+            $values['contractPeriodStart'] = trim($split[0]);
+            $values['contractPeriodEnd'] = trim($split[1]);
+        }
+
+        // var_dump($values);
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/CfiaHandler.php
+++ b/app/DepartmentHandlers/CfiaHandler.php
@@ -4,119 +4,119 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class CfiaHandler extends DepartmentHandler {
+class CfiaHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.inspection.gc.ca/active/eng/agen/proactive/contra/raprte.asp';
-	public $baseUrl = 'http://www.inspection.gc.ca/';
-	public $ownerAcronym = 'cfia';
+    public $indexUrl = 'http://www.inspection.gc.ca/active/eng/agen/proactive/contra/raprte.asp';
+    public $baseUrl = 'http://www.inspection.gc.ca/';
+    public $ownerAcronym = 'cfia';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	// Quarters are returned as absolute URLs, so no quarterToContractUrlTransform needed.
-	/*
+    // Quarters are returned as absolute URLs, so no quarterToContractUrlTransform needed.
+    /*
 	public function quarterToContractUrlTransform($contractUrl) {
 		return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
 	}
 	*/
 
-	// Ignore the latest quarter that uses "open.canada.ca" as a link instead.
-	// We'll need to retrieve those from the actual dataset.
-	public function filterQuarterUrls($quarterUrls) {
+    // Ignore the latest quarter that uses "open.canada.ca" as a link instead.
+    // We'll need to retrieve those from the actual dataset.
+    public function filterQuarterUrls($quarterUrls)
+    {
 
-		// Remove the new entries with "open.canada.ca"
-		$quarterUrls = array_filter($quarterUrls, function($url) {
-			if(strpos($url, 'open.canada.ca') !== false) {
-				return false;
-			}
-			return true;
-		});
+        // Remove the new entries with "open.canada.ca"
+        $quarterUrls = array_filter($quarterUrls, function ($url) {
+            if (strpos($url, 'open.canada.ca') !== false) {
+                return false;
+            }
+            return true;
+        });
 
-		return $quarterUrls;
-	}
+        return $quarterUrls;
+    }
 
-	/*
+    /*
 	public function indexToQuarterUrlTransform($url) {
 		return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
 	}
 	*/
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output ='year') {
+    public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output = 'year')
+    {
 
-		// Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
+        // Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
 
-		$quarterIndex = [
-			'January 1 - March 31' => 4,
-			'April 1 - June 30' => 1,
-			'July 1 - September 30' => 2,
-			'October 1 - December 31' => 3,
-		];
+        $quarterIndex = [
+            'January 1 - March 31' => 4,
+            'April 1 - June 30' => 1,
+            'July 1 - September 30' => 2,
+            'October 1 - December 31' => 3,
+        ];
 
-		$fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//main/h1", '/([0-9]{4})/');
-		$fiscalQuarter = '';
+        $fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//main/h1", '/([0-9]{4})/');
+        $fiscalQuarter = '';
 
 
 // \w
-		$title = Helpers::xpathRegexComboSearch($quarterHtml, "//main/h1", '/(.*)/');
+        $title = Helpers::xpathRegexComboSearch($quarterHtml, "//main/h1", '/(.*)/');
 
-		// Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
-		foreach($quarterIndex as $quarterLabel => $quarterKey) {
-			if(strpos($title, $quarterLabel) !== false) {
-				$fiscalQuarter = $quarterKey;
-				break;
-			}
-		}
+        // Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
+        foreach ($quarterIndex as $quarterLabel => $quarterKey) {
+            if (strpos($title, $quarterLabel) !== false) {
+                $fiscalQuarter = $quarterKey;
+                break;
+            }
+        }
 
-		if($output == 'year') {
-			return $fiscalYear;
-		}
-		else {
-			return $fiscalQuarter;
-		}
+        if ($output == 'year') {
+            return $fiscalYear;
+        } else {
+            return $fiscalQuarter;
+        }
+    }
 
-	}
+    public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl) {
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    }
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	}
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+    }
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl) {
+    public function parseHtml($html)
+    {
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+        $keyArray = [
+            'vendorName' => 'Vendor Name',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Date',
+            'description' => 'Description of work',
+            'extraDescription' => 'Detailed Description',
+            'contractPeriodStart' => 'Contract Start Date',
+            'contractPeriodEnd' => 'Contract End Date',
+            'contractPeriodRange' => '',
+            'deliveryDate' => 'Delivery Date',
+            'originalValue' => 'Original Contract Value',
+            'contractValue' => 'Contract Value',
+            'comments' => 'Comments',
+        ];
 
-	}
+        // CFIA has occasional HTML errors, such as
+        // http://www.inspection.gc.ca/active/scripts/agen/proactive/contra/contrarport.asp?lang=e&yr=2016-2017&q=2&contraID=17443&yid=13
+        // In these cases the data isn't properly returned from the server, so the parsed data will be missing entries.
 
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Date',
-			'description' => 'Description of work',
-			'extraDescription' => 'Detailed Description',
-			'contractPeriodStart' => 'Contract Start Date',
-			'contractPeriodEnd' => 'Contract End Date',
-			'contractPeriodRange' => '',
-			'deliveryDate' => 'Delivery Date',
-			'originalValue' => 'Original Contract Value',
-			'contractValue' => 'Contract Value',
-			'comments' => 'Comments',
-		];
-
-		// CFIA has occasional HTML errors, such as
-		// http://www.inspection.gc.ca/active/scripts/agen/proactive/contra/contrarport.asp?lang=e&yr=2016-2017&q=2&contraID=17443&yid=13
-		// In these cases the data isn't properly returned from the server, so the parsed data will be missing entries.
-
-		return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/DndHandler.php
+++ b/app/DepartmentHandlers/DndHandler.php
@@ -4,69 +4,71 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class DndHandler extends DepartmentHandler {
+class DndHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.admfincs.forces.gc.ca/apps/dc/intro-eng.asp';
-	public $baseUrl = 'http://www.admfincs.forces.gc.ca/';
-	public $ownerAcronym = 'dnd';
+    public $indexUrl = 'http://www.admfincs.forces.gc.ca/apps/dc/intro-eng.asp';
+    public $baseUrl = 'http://www.admfincs.forces.gc.ca/';
+    public $ownerAcronym = 'dnd';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@id='main']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@id='main']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@id='container']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@id='container']//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.admfincs.forces.gc.ca/apps/dc/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.admfincs.forces.gc.ca/apps/dc/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.admfincs.forces.gc.ca/apps/dc/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.admfincs.forces.gc.ca/apps/dc/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//div[@id='main']";
+    public $contractContentSubsetXpath = "//div[@id='main']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='mc-cp']", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='mc-cp']", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='mc-cp']", '/([0-9]):/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='mc-cp']", '/([0-9]):/');
+    public function parseHtml($html)
+    {
 
-	}
+        // DND doesn't include a contract period range, or an original value.
+        // They also have wild date formats (eg. "9-2-2017")
 
-	public function parseHtml($html) {
+        $keyArray = [
+            'vendorName' => 'Vendor Name',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Contract Date',
+            'description' => 'Description of work',
+            'extraDescription' => 'Additional Comments',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period',
+            'deliveryDate' => 'Delivery Date',
+            'originalValue' => '',
+            'contractValue' => 'Contract Value',
+            'comments' => 'Comments',
+        ];
 
-		// DND doesn't include a contract period range, or an original value.
-		// They also have wild date formats (eg. "9-2-2017")
+        $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
 
-		$keyArray = [
-			'vendorName' => 'Vendor Name',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Contract Date',
-			'description' => 'Description of work',
-			'extraDescription' => 'Additional Comments',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period',
-			'deliveryDate' => 'Delivery Date',
-			'originalValue' => '',
-			'contractValue' => 'Contract Value',
-			'comments' => 'Comments',
-		];
+        
 
-	    $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
-
-	    
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/EcHandler.php
+++ b/app/DepartmentHandlers/EcHandler.php
@@ -4,47 +4,49 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class EcHandler extends DepartmentHandler {
+class EcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.ec.gc.ca/contracts-contrats/index.cfm?lang=En&state=reports';
-	public $baseUrl = 'http://www.ec.gc.ca/contracts-contrats/';
-	public $ownerAcronym = 'ec';
+    public $indexUrl = 'http://www.ec.gc.ca/contracts-contrats/index.cfm?lang=En&state=reports';
+    public $baseUrl = 'http://www.ec.gc.ca/contracts-contrats/';
+    public $ownerAcronym = 'ec';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@id='wb-main']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@id='wb-main']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@id='cn-centre-col-inner']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@id='cn-centre-col-inner']//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.ec.gc.ca/contracts-contrats/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.ec.gc.ca/contracts-contrats/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.ec.gc.ca/contracts-contrats/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.ec.gc.ca/contracts-contrats/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//div[@id='cn-centre-col-inner']";
+    public $contractContentSubsetXpath = "//div[@id='cn-centre-col-inner']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@id='cn-centre-col-inner']//h1", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@id='cn-centre-col-inner']//h1", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@id='cn-centre-col-inner']//h1", '/([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@id='cn-centre-col-inner']//h1", '/([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
-
-	public function parseHtml($html) {
-
-		return Helpers::genericXpathParser($html, "//table//td[@scope='row']", "//table//td[@class='alignTopLeft']", ' to ');
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//td[@scope='row']", "//table//td[@class='alignTopLeft']", ' to ');
+    }
 }

--- a/app/DepartmentHandlers/EsdcHandler.php
+++ b/app/DepartmentHandlers/EsdcHandler.php
@@ -4,68 +4,70 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class EsdcHandler extends DepartmentHandler {
+class EsdcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://disclosure.esdc.gc.ca/dp-pd/prdlstcdn-eng.jsp?site=1&section=2';
-	public $baseUrl = 'http://disclosure.esdc.gc.ca/';
-	public $ownerAcronym = 'esdc';
+    public $indexUrl = 'http://disclosure.esdc.gc.ca/dp-pd/prdlstcdn-eng.jsp?site=1&section=2';
+    public $baseUrl = 'http://disclosure.esdc.gc.ca/';
+    public $ownerAcronym = 'esdc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://disclosure.esdc.gc.ca/dp-pd/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://disclosure.esdc.gc.ca/dp-pd/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://disclosure.esdc.gc.ca/dp-pd/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://disclosure.esdc.gc.ca/dp-pd/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/\s([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/\s([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
+        // Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
 
-	public function parseHtml($html) {
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Description (more details):',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => '',
+            'contractValue' => 'Current Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-		// Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
+        $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
 
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Description (more details):',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => '',
-			'contractValue' => 'Current Contract Value:',
-			'comments' => 'Comments:',
-		];
+        
 
-	    $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
-
-	    
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/HcHandler.php
+++ b/app/DepartmentHandlers/HcHandler.php
@@ -4,68 +4,70 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class HcHandler extends DepartmentHandler {
+class HcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.contracts-contrats.hc-sc.gc.ca/cfob/mssid/contractdisc.nsf/webGetbyperiod?OpenView&Count=1000&ExpandAll&lang=eng&';
-	public $baseUrl = 'http://www.contracts-contrats.hc-sc.gc.ca/';
-	public $ownerAcronym = 'hc';
+    public $indexUrl = 'http://www.contracts-contrats.hc-sc.gc.ca/cfob/mssid/contractdisc.nsf/webGetbyperiod?OpenView&Count=1000&ExpandAll&lang=eng&';
+    public $baseUrl = 'http://www.contracts-contrats.hc-sc.gc.ca/';
+    public $ownerAcronym = 'hc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@class='center']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@class='center']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@class='center']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@class='center']//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.contracts-contrats.hc-sc.gc.ca/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.contracts-contrats.hc-sc.gc.ca/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.contracts-contrats.hc-sc.gc.ca/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.contracts-contrats.hc-sc.gc.ca/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//div[@class='center']";
+    public $contractContentSubsetXpath = "//div[@class='center']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9])[a-z]/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9])[a-z]/');
+    public function parseHtml($html)
+    {
 
-	}
+        // Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
 
-	public function parseHtml($html) {
+        $keyArray = [
+            'vendorName' => 'Vendor Name',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Contract Date',
+            'description' => 'Description',
+            'extraDescription' => 'Document Type',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period',
+            'deliveryDate' => 'Delivery Date',
+            'originalValue' => 'Original Contract Value',
+            'contractValue' => 'Overall Contract Value',
+            'comments' => 'Comments',
+        ];
 
-		// Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
+        $values = Helpers::genericXpathParser($html, "//h2", "//p", 'to', $keyArray);
 
-		$keyArray = [
-			'vendorName' => 'Vendor Name',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Contract Date',
-			'description' => 'Description',
-			'extraDescription' => 'Document Type',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period',
-			'deliveryDate' => 'Delivery Date',
-			'originalValue' => 'Original Contract Value',
-			'contractValue' => 'Overall Contract Value',
-			'comments' => 'Comments',
-		];
+        
 
-	    $values = Helpers::genericXpathParser($html, "//h2", "//p", 'to', $keyArray);
-
-	    
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/IcHandler.php
+++ b/app/DepartmentHandlers/IcHandler.php
@@ -4,115 +4,115 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class IcHandler extends DepartmentHandler {
+class IcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'https://www.ic.gc.ca/app/scr/ic/cr/quarters.html?lang=eng';
-	public $baseUrl = 'https://www.ic.gc.ca/';
-	public $ownerAcronym = 'ic';
+    public $indexUrl = 'https://www.ic.gc.ca/app/scr/ic/cr/quarters.html?lang=eng';
+    public $baseUrl = 'https://www.ic.gc.ca/';
+    public $ownerAcronym = 'ic';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@role='main']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@role='main']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@role='main']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@role='main']//table//td//a/@href";
 
-	// public function quarterToContractUrlTransform($contractUrl) {
-	// 	return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
-	// }
+    // public function quarterToContractUrlTransform($contractUrl) {
+    // 	return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
+    // }
 
-	// public function indexToQuarterUrlTransform($url) {
-	// 	return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
-	// }
+    // public function indexToQuarterUrlTransform($url) {
+    // 	return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
+    // }
 
-	public $contractContentSubsetXpath = "//div[@role='main']";
+    public $contractContentSubsetXpath = "//div[@role='main']";
 
-	public function removeSessionIdsFromUrl($url) {
+    public function removeSessionIdsFromUrl($url)
+    {
 
-		// Changes URLs from
-		// "/app/scr/ic/cr/contract.html;jsessionid=00016skqjTiJbbz1GakSKZcquPJ:-3001ID?id=205786"
-		// to
-		// "/app/scr/ic/cr/contract.html?id=205786"
+        // Changes URLs from
+        // "/app/scr/ic/cr/contract.html;jsessionid=00016skqjTiJbbz1GakSKZcquPJ:-3001ID?id=205786"
+        // to
+        // "/app/scr/ic/cr/contract.html?id=205786"
 
-		$url = preg_replace('/;([^?]*)?/i', '', $url);
-		return $url;
-	}
+        $url = preg_replace('/;([^?]*)?/i', '', $url);
+        return $url;
+    }
 
-	public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output ='year') {
+    public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output = 'year')
+    {
 
-		// Somewhat confusingly, IC (like IRCC) indexes quarters by calendar year instead of by fiscal year.
+        // Somewhat confusingly, IC (like IRCC) indexes quarters by calendar year instead of by fiscal year.
 
-		$quarterIndex = [
-			'January 1 to March 31' => 4,
-			'April 1 to June 30' => 1,
-			'July 1 to September 30' => 2,
-			'October 1 to December 31' => 3,
-		];
+        $quarterIndex = [
+            'January 1 to March 31' => 4,
+            'April 1 to June 30' => 1,
+            'July 1 to September 30' => 2,
+            'October 1 to December 31' => 3,
+        ];
 
-		$fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@class='printHeader']", '/([0-9]{4})/');
-		$fiscalQuarter = '';
+        $fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@class='printHeader']", '/([0-9]{4})/');
+        $fiscalQuarter = '';
 
 
 // \w
-		$title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@class='printHeader']");
+        $title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@class='printHeader']");
 
-		$title = str_replace(["\n", "\r", "\t"], ' ', $title);
-		$title = str_replace(["   ", "  "], ' ', $title);
+        $title = str_replace(["\n", "\r", "\t"], ' ', $title);
+        $title = str_replace(["   ", "  "], ' ', $title);
 
-		// Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
-		foreach($quarterIndex as $quarterLabel => $quarterKey) {
-			if(strpos($title, $quarterLabel) !== false) {
-				$fiscalQuarter = $quarterKey;
-				break;
-			}
-		}
+        // Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
+        foreach ($quarterIndex as $quarterLabel => $quarterKey) {
+            if (strpos($title, $quarterLabel) !== false) {
+                $fiscalQuarter = $quarterKey;
+                break;
+            }
+        }
 
-		// Correction to keep these aligned with fiscal-year based entries.
-		// For example, when IC has "January 1 - March 31, 2016", other departments would have "2015-2016 Q4" and so the operative year would actually be 2015.
-		if($fiscalQuarter == 4) {
-			$fiscalYear -= 1;
-		}
+        // Correction to keep these aligned with fiscal-year based entries.
+        // For example, when IC has "January 1 - March 31, 2016", other departments would have "2015-2016 Q4" and so the operative year would actually be 2015.
+        if ($fiscalQuarter == 4) {
+            $fiscalYear -= 1;
+        }
 
-		if($output == 'year') {
-			return $fiscalYear;
-		}
-		else {
-			return $fiscalQuarter;
-		}
+        if ($output == 'year') {
+            return $fiscalYear;
+        } else {
+            return $fiscalQuarter;
+        }
+    }
 
-	}
+    public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl) {
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    }
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	}
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+    }
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl) {
+    public function parseHtml($html)
+    {
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+        $keyArray = [
+            'vendorName' => 'Vendor Name',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Contract Date',
+            'description' => 'Description',
+            'extraDescription' => 'Additional Comments',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract period / delivery date',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Original Contract Value',
+            'contractValue' => 'Contract Value',
+            'comments' => 'Comment',
+        ];
 
-	}
-
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Contract Date',
-			'description' => 'Description',
-			'extraDescription' => 'Additional Comments',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract period / delivery date',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Original Contract Value',
-			'contractValue' => 'Contract Value',
-			'comments' => 'Comment',
-		];
-
-		return Helpers::genericXpathParser($html, "//div[@class='formTable']//div[@class='ic2col1 formLeftCol']", "//div[@class='formTable']//div[@class='ic2col2 formRightCol']", ' - ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//div[@class='formTable']//div[@class='ic2col1 formLeftCol']", "//div[@class='formTable']//div[@class='ic2col2 formRightCol']", ' - ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/InacHandler.php
+++ b/app/DepartmentHandlers/InacHandler.php
@@ -4,39 +4,39 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class InacHandler extends DepartmentHandler {
+class InacHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.aadnc-aandc.gc.ca/prodis/cntrcts/rprts-eng.asp';
-	public $baseUrl = 'http://www.aadnc-aandc.gc.ca/';
-	public $ownerAcronym = 'inac';
+    public $indexUrl = 'http://www.aadnc-aandc.gc.ca/prodis/cntrcts/rprts-eng.asp';
+    public $baseUrl = 'http://www.aadnc-aandc.gc.ca/';
+    public $ownerAcronym = 'inac';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@class='center']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@class='center']//ul/li/a/@href";
 
-	public $multiPage = 1;
-	public $quarterMultiPageXpath = "//div[@class='align-right size-small']/a/@href";
+    public $multiPage = 1;
+    public $quarterMultiPageXpath = "//div[@class='align-right size-small']/a/@href";
 
-	public $quarterToContractXpath = "//table[@class='widthFull TableBorderBasic']//td//a/@href";
+    public $quarterToContractXpath = "//table[@class='widthFull TableBorderBasic']//td//a/@href";
 
-	public $contractContentSubsetXpath = "//div[@class='center']";
+    public $contractContentSubsetXpath = "//div[@class='center']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <title>Disclosure of Contracts - 2016-2017 - 3rd Quarter - Indigenous and Northern Affairs Canada</title>
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//title", '/([0-9]{4})/');
+        // <title>Disclosure of Contracts - 2016-2017 - 3rd Quarter - Indigenous and Northern Affairs Canada</title>
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//title", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//title", '/-\s([0-9])[a-z]/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//title", '/-\s([0-9])[a-z]/');
+    public function parseHtml($html)
+    {
 
-	}
-
-	public function parseHtml($html) {
-
-		return Helpers::genericXpathParser($html, "//table[@class='widthFull TableBorderBasic']//th", "//table[@class='widthFull TableBorderBasic']//td", ' - ');
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table[@class='widthFull TableBorderBasic']//th", "//table[@class='widthFull TableBorderBasic']//td", ' - ');
+    }
 }

--- a/app/DepartmentHandlers/IrccHandler.php
+++ b/app/DepartmentHandlers/IrccHandler.php
@@ -4,87 +4,88 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class IrccHandler extends DepartmentHandler {
+class IrccHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.cic.gc.ca/disclosure-divulgation/index-eng.aspx';
-	public $baseUrl = 'http://www.cic.gc.ca/';
-	public $ownerAcronym = 'ircc';
+    public $indexUrl = 'http://www.cic.gc.ca/disclosure-divulgation/index-eng.aspx';
+    public $baseUrl = 'http://www.cic.gc.ca/';
+    public $ownerAcronym = 'ircc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//form[@id='aspnetForm']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//form[@id='aspnetForm']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//form[@id='aspnetForm']//table//td//a/@href";
+    public $quarterToContractXpath = "//form[@id='aspnetForm']//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//form[@id='aspnetForm']";
+    public $contractContentSubsetXpath = "//form[@id='aspnetForm']";
 
-	public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output ='year') {
+    public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output = 'year')
+    {
 
-		// Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
+        // Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
 
-		$quarterIndex = [
-			'January 1 - March 31' => 4,
-			'April 1 - June 30' => 1,
-			'July 1 - September 30' => 2,
-			'October 1 - December 31' => 3,
-		];
+        $quarterIndex = [
+            'January 1 - March 31' => 4,
+            'April 1 - June 30' => 1,
+            'July 1 - September 30' => 2,
+            'October 1 - December 31' => 3,
+        ];
 
-		$fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
-		$fiscalQuarter = '';
+        $fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+        $fiscalQuarter = '';
 
 
 // \w
-		$title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
+        $title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
 
-		// Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
-		foreach($quarterIndex as $quarterLabel => $quarterKey) {
-			if(strpos($title, $quarterLabel) !== false) {
-				$fiscalQuarter = $quarterKey;
-				break;
-			}
-		}
+        // Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
+        foreach ($quarterIndex as $quarterLabel => $quarterKey) {
+            if (strpos($title, $quarterLabel) !== false) {
+                $fiscalQuarter = $quarterKey;
+                break;
+            }
+        }
 
-		// Correction to keep these aligned with fiscal-year based entries.
-		// For example, when IRCC has "January 1 - March 31, 2016", other departments would have "2015-2016 Q4" and so the operative year would actually be 2015.
-		// TODO - ask someone to doublecheck this logic.
-		if($fiscalQuarter == 4) {
-			$fiscalYear -= 1;
-		}
+        // Correction to keep these aligned with fiscal-year based entries.
+        // For example, when IRCC has "January 1 - March 31, 2016", other departments would have "2015-2016 Q4" and so the operative year would actually be 2015.
+        // TODO - ask someone to doublecheck this logic.
+        if ($fiscalQuarter == 4) {
+            $fiscalYear -= 1;
+        }
 
-		if($output == 'year') {
-			return $fiscalYear;
-		}
-		else {
-			return $fiscalQuarter;
-		}
+        if ($output == 'year') {
+            return $fiscalYear;
+        } else {
+            return $fiscalQuarter;
+        }
+    }
 
-	}
+    public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl) {
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    }
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	}
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+    }
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl) {
+    public function parseHtml($html)
+    {
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
-
-	}
-
-	public function parseHtml($html) {
-
-		return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ');
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ');
+    }
 }

--- a/app/DepartmentHandlers/IrccPcHandler.php
+++ b/app/DepartmentHandlers/IrccPcHandler.php
@@ -5,96 +5,97 @@ use App\DepartmentHandler;
 use App\Helpers;
 
 // Passport Canada (now part of IRCC)
-class IrccPcHandler extends DepartmentHandler {
+class IrccPcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.cic.gc.ca/disclosure-divulgation/cont-eng.aspx';
-	public $baseUrl = 'http://www.cic.gc.ca/';
-	public $ownerAcronym = 'ircc-pc';
+    public $indexUrl = 'http://www.cic.gc.ca/disclosure-divulgation/cont-eng.aspx';
+    public $baseUrl = 'http://www.cic.gc.ca/';
+    public $ownerAcronym = 'ircc-pc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.cic.gc.ca/disclosure-divulgation/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//form[@id='aspnetForm']";
+    public $contractContentSubsetXpath = "//form[@id='aspnetForm']";
 
-	public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output ='year') {
+    public function fiscalYearAndQuarterFromIrccTitle($quarterHtml, $output = 'year')
+    {
 
-		// Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
+        // Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
 
-		$quarterIndex = [
-			'January 1 - March 31' => 4,
-			'April 1 - June 30' => 1,
-			'July 1 - September 30' => 2,
-			'October 1 - December 31' => 3,
-		];
+        $quarterIndex = [
+            'January 1 - March 31' => 4,
+            'April 1 - June 30' => 1,
+            'July 1 - September 30' => 2,
+            'October 1 - December 31' => 3,
+        ];
 
-		$fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
-		$fiscalQuarter = '';
+        $fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+        $fiscalQuarter = '';
 
 
 // \w
-		$title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
+        $title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
 
-		// Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
-		foreach($quarterIndex as $quarterLabel => $quarterKey) {
-			if(strpos($title, $quarterLabel) !== false) {
-				$fiscalQuarter = $quarterKey;
-				break;
-			}
-		}
+        // Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
+        foreach ($quarterIndex as $quarterLabel => $quarterKey) {
+            if (strpos($title, $quarterLabel) !== false) {
+                $fiscalQuarter = $quarterKey;
+                break;
+            }
+        }
 
-		if($output == 'year') {
-			return $fiscalYear;
-		}
-		else {
-			return $fiscalQuarter;
-		}
+        if ($output == 'year') {
+            return $fiscalYear;
+        } else {
+            return $fiscalQuarter;
+        }
+    }
 
-	}
+    public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl) {
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    }
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'year');
+    public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	}
+        return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+    }
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl) {
+    public function parseHtml($html)
+    {
 
-		return $this->fiscalYearAndQuarterFromIrccTitle($quarterHtml, 'quarter');
+        // Passport Canada has a typo in "Vender name"
+        $keyArray = [
+            'vendorName' => 'Vender Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Description (more details):',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => '',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-	}
-
-	public function parseHtml($html) {
-
-		// Passport Canada has a typo in "Vender name"
-		$keyArray = [
-			'vendorName' => 'Vender Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Description (more details):',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => '',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
-
-		return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/JustHandler.php
+++ b/app/DepartmentHandlers/JustHandler.php
@@ -4,66 +4,68 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class JustHandler extends DepartmentHandler {
+class JustHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.justice.gc.ca/eng/trans/pd-dp/contra/rep-rap.asp';
-	public $baseUrl = 'http://www.justice.gc.ca/';
-	public $ownerAcronym = 'just';
+    public $indexUrl = 'http://www.justice.gc.ca/eng/trans/pd-dp/contra/rep-rap.asp';
+    public $baseUrl = 'http://www.justice.gc.ca/';
+    public $ownerAcronym = 'just';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.justice.gc.ca/eng/trans/pd-dp/contra/" . $contractUrl;
-	}
-	
+    
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.justice.gc.ca/eng/trans/pd-dp/contra/" . $contractUrl;
+    }
+    
 
-	
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.justice.gc.ca/eng/trans/pd-dp/contra/" . $url;
-	}
-	
+    
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.justice.gc.ca/eng/trans/pd-dp/contra/" . $url;
+    }
+    
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Additional Comments:',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Original Contract Value:',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Additional Comments:',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Original Contract Value:',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
-
-		return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/NrcanHandler.php
+++ b/app/DepartmentHandlers/NrcanHandler.php
@@ -4,66 +4,68 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class NrcanHandler extends DepartmentHandler {
+class NrcanHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www2.nrcan-rncan.gc.ca/dc-dpm/index.cfm?fuseaction=r.q&lang=eng';
-	public $baseUrl = 'http://www2.nrcan-rncan.gc.ca/';
-	public $ownerAcronym = 'nrcan';
+    public $indexUrl = 'http://www2.nrcan-rncan.gc.ca/dc-dpm/index.cfm?fuseaction=r.q&lang=eng';
+    public $baseUrl = 'http://www2.nrcan-rncan.gc.ca/';
+    public $ownerAcronym = 'nrcan';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www2.nrcan-rncan.gc.ca/dc-dpm/" . $contractUrl;
-	}
-	
+    
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www2.nrcan-rncan.gc.ca/dc-dpm/" . $contractUrl;
+    }
+    
 
-	
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www2.nrcan-rncan.gc.ca/dc-dpm/" . $url;
-	}
-	
+    
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www2.nrcan-rncan.gc.ca/dc-dpm/" . $url;
+    }
+    
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9])[a-z]/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9])[a-z]/');
+    public function parseHtml($html)
+    {
 
-	}
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Additional Comments:',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Original Contract Value:',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Additional Comments:',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Original Contract Value:',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
-
-		return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/PcHandler.php
+++ b/app/DepartmentHandlers/PcHandler.php
@@ -4,66 +4,68 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class PcHandler extends DepartmentHandler {
+class PcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.pc.gc.ca/apps/pdc/index_e.asp?oqYEAR=&oqQUARTER=';
-	public $baseUrl = 'http://www.pc.gc.ca/';
-	public $ownerAcronym = 'pc';
+    public $indexUrl = 'http://www.pc.gc.ca/apps/pdc/index_e.asp?oqYEAR=&oqQUARTER=';
+    public $baseUrl = 'http://www.pc.gc.ca/';
+    public $ownerAcronym = 'pc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.pc.gc.ca/apps/pdc/" . $contractUrl;
-	}
-	
+    
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.pc.gc.ca/apps/pdc/" . $contractUrl;
+    }
+    
 
-	
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.pc.gc.ca/apps/pdc/" . $url;
-	}
-	
+    
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.pc.gc.ca/apps/pdc/" . $url;
+    }
+    
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9])[a-z]/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h2", '/([0-9])[a-z]/');
+    public function parseHtml($html)
+    {
 
-	}
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Additional Comments:',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Original Contract Value:',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Additional Comments:',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Original Contract Value:',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
-
-		return Helpers::genericXpathParser($html, "//form//label", "//form//p", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//form//label", "//form//p", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/PhacHandler.php
+++ b/app/DepartmentHandlers/PhacHandler.php
@@ -4,68 +4,70 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class PhacHandler extends DepartmentHandler {
+class PhacHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.contracts-contrats.phac-aspc.gc.ca/cfob/mssid/contractdisc.nsf/webGetbyperiod?OpenView&Count=1000&ExpandAll&lang=eng&';
-	public $baseUrl = 'http://www.contracts-contrats.phac-aspc.gc.ca/';
-	public $ownerAcronym = 'phac';
+    public $indexUrl = 'http://www.contracts-contrats.phac-aspc.gc.ca/cfob/mssid/contractdisc.nsf/webGetbyperiod?OpenView&Count=1000&ExpandAll&lang=eng&';
+    public $baseUrl = 'http://www.contracts-contrats.phac-aspc.gc.ca/';
+    public $ownerAcronym = 'phac';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@class='center']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@class='center']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@class='center']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@class='center']//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.contracts-contrats.phac-aspc.gc.ca/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.contracts-contrats.phac-aspc.gc.ca/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.contracts-contrats.phac-aspc.gc.ca/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.contracts-contrats.phac-aspc.gc.ca/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//div[@class='center']";
+    public $contractContentSubsetXpath = "//div[@class='center']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9])[a-z]/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//div[@class='center']//h1", '/([0-9])[a-z]/');
+    public function parseHtml($html)
+    {
 
-	}
+        // Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
 
-	public function parseHtml($html) {
+        $keyArray = [
+            'vendorName' => 'Vendor Name',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Contract Date',
+            'description' => 'Description',
+            'extraDescription' => 'Document Type',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period',
+            'deliveryDate' => 'Delivery Date',
+            'originalValue' => 'Original Contract Value',
+            'contractValue' => 'Overall Contract Value',
+            'comments' => 'Comments',
+        ];
 
-		// Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
+        $values = Helpers::genericXpathParser($html, "//h2", "//p", 'to', $keyArray);
 
-		$keyArray = [
-			'vendorName' => 'Vendor Name',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Contract Date',
-			'description' => 'Description',
-			'extraDescription' => 'Document Type',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period',
-			'deliveryDate' => 'Delivery Date',
-			'originalValue' => 'Original Contract Value',
-			'contractValue' => 'Overall Contract Value',
-			'comments' => 'Comments',
-		];
+        
 
-	    $values = Helpers::genericXpathParser($html, "//h2", "//p", 'to', $keyArray);
-
-	    
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/PspcHandler.php
+++ b/app/DepartmentHandlers/PspcHandler.php
@@ -4,68 +4,68 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class PspcHandler extends DepartmentHandler {
+class PspcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.tpsgc-pwgsc.gc.ca/cgi-bin/proactive/cl.pl?lang=eng&SCR=Q&Sort=0';
-	public $baseUrl = 'http://www.tpsgc-pwgsc.gc.ca/';
-	public $ownerAcronym = 'pspc';
+    public $indexUrl = 'http://www.tpsgc-pwgsc.gc.ca/cgi-bin/proactive/cl.pl?lang=eng&SCR=Q&Sort=0';
+    public $baseUrl = 'http://www.tpsgc-pwgsc.gc.ca/';
+    public $ownerAcronym = 'pspc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@id='wb-main-in']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@id='wb-main-in']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@id='wb-main-in']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@id='wb-main-in']//table//td//a/@href";
 
-	// public function quarterToContractUrlTransform($contractUrl) {
-	// 	return "http://disclosure.esdc.gc.ca/dp-pd/" . $contractUrl;
-	// }
+    // public function quarterToContractUrlTransform($contractUrl) {
+    // 	return "http://disclosure.esdc.gc.ca/dp-pd/" . $contractUrl;
+    // }
 
-	// public function indexToQuarterUrlTransform($url) {
-	// 	return "http://disclosure.esdc.gc.ca/dp-pd/" . $url;
-	// }
+    // public function indexToQuarterUrlTransform($url) {
+    // 	return "http://disclosure.esdc.gc.ca/dp-pd/" . $url;
+    // }
 
-	public $contractContentSubsetXpath = "//div[@id='wb-main-in']";
+    public $contractContentSubsetXpath = "//div[@id='wb-main-in']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/\s([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/\s([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
+        // Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
 
-	public function parseHtml($html) {
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Description (more details):',
+            'contractPeriodStart' => 'Contract Period - From',
+            'contractPeriodEnd' => 'Contract Period - To',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Contract Value',
+            'contractValue' => 'Total Amended Contract Value',
+            'comments' => 'Comments:',
+        ];
 
-		// Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
+        $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
 
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Description (more details):',
-			'contractPeriodStart' => 'Contract Period - From',
-			'contractPeriodEnd' => 'Contract Period - To',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Contract Value',
-			'contractValue' => 'Total Amended Contract Value',
-			'comments' => 'Comments:',
-		];
+        
 
-	    $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
-
-	    
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/RcmpHandler.php
+++ b/app/DepartmentHandlers/RcmpHandler.php
@@ -4,69 +4,71 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class RcmpHandler extends DepartmentHandler {
+class RcmpHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.rcmp-grc.gc.ca/en/contra/?lst=1';
-	public $baseUrl = 'http://www.rcmp-grc.gc.ca/';
-	public $ownerAcronym = 'rcmp';
+    public $indexUrl = 'http://www.rcmp-grc.gc.ca/en/contra/?lst=1';
+    public $baseUrl = 'http://www.rcmp-grc.gc.ca/';
+    public $ownerAcronym = 'rcmp';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//table[@class='wb-tables table table-striped']//td//a/@href";
+    public $quarterToContractXpath = "//table[@class='wb-tables table table-striped']//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.rcmp-grc.gc.ca/en/contra/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.rcmp-grc.gc.ca/en/contra/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.rcmp-grc.gc.ca/en/contra/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.rcmp-grc.gc.ca/en/contra/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/,\s([0-9])/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/,\s([0-9])/');
+    public function parseHtml($html)
+    {
 
-	}
+        $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to');
 
-	public function parseHtml($html) {
+        // The RCMP includes both original and amended values in the same cell, but only displays the amended value when there is one (seemingly, most of the time). This tries to re-split these into separate fields.
 
-	    $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to');
+        // Amended value is first, then original.
+        // For example,
+        // Amended contract value:$45,375.00Original contract value:$32,450.00
 
-	    // The RCMP includes both original and amended values in the same cell, but only displays the amended value when there is one (seemingly, most of the time). This tries to re-split these into separate fields.
+        $contractValueSplit = str_replace('Amended contract value:', '', $values['contractValue']);
+        $contractValueSplit = explode('Original contract value:', $contractValueSplit);
 
-	    // Amended value is first, then original.
-	    // For example,
-	    // Amended contract value:$45,375.00Original contract value:$32,450.00
+        $amendedValue = $contractValueSplit[0];
+        $originalValue = $contractValueSplit[1];
 
-	    $contractValueSplit = str_replace('Amended contract value:', '', $values['contractValue']);
-	    $contractValueSplit = explode('Original contract value:', $contractValueSplit);
+        if ($originalValue) {
+            $values['originalValue'] = $originalValue;
+            $values['contractValue'] = $originalValue;
+        }
+        if ($amendedValue) {
+            $values['contractValue'] = $amendedValue;
+        }
 
-	    $amendedValue = $contractValueSplit[0];
-	    $originalValue = $contractValueSplit[1];
-
-	    if($originalValue) {
-	        $values['originalValue'] = $originalValue;
-	        $values['contractValue'] = $originalValue;
-	    }
-	    if($amendedValue) {
-	        $values['contractValue'] = $amendedValue;
-	    }
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/ScHandler.php
+++ b/app/DepartmentHandlers/ScHandler.php
@@ -4,68 +4,70 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class ScHandler extends DepartmentHandler {
+class ScHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://disclosure.servicecanada.gc.ca/dp-pd/prdlstcdn-eng.jsp?site=3&section=2';
-	public $baseUrl = 'http://disclosure.servicecanada.gc.ca/';
-	public $ownerAcronym = 'sc';
+    public $indexUrl = 'http://disclosure.servicecanada.gc.ca/dp-pd/prdlstcdn-eng.jsp?site=3&section=2';
+    public $baseUrl = 'http://disclosure.servicecanada.gc.ca/';
+    public $ownerAcronym = 'sc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://disclosure.servicecanada.gc.ca/dp-pd/" . $contractUrl;
-	}
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://disclosure.servicecanada.gc.ca/dp-pd/" . $contractUrl;
+    }
 
-	public function indexToQuarterUrlTransform($url) {
-		return "http://disclosure.servicecanada.gc.ca/dp-pd/" . $url;
-	}
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://disclosure.servicecanada.gc.ca/dp-pd/" . $url;
+    }
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/\s([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//h2", '/\s([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
+        // Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
 
-	public function parseHtml($html) {
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Description (more details):',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => '',
+            'contractValue' => 'Current Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-		// Service Canada doesn't include an "original contract value" on their entries. Only the current contract value is listed.
+        $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
 
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Description (more details):',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => '',
-			'contractValue' => 'Current Contract Value:',
-			'comments' => 'Comments:',
-		];
+        
 
-	    $values = Helpers::genericXpathParser($html, "//table//th", "//table//td", 'to', $keyArray);
-
-	    
-
-	    return $values;
-
-	}
-
+        return $values;
+    }
 }

--- a/app/DepartmentHandlers/SscHandler.php
+++ b/app/DepartmentHandlers/SscHandler.php
@@ -4,20 +4,21 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class SscHandler extends DepartmentHandler {
+class SscHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.ssc-spc.gc.ca/pages/contracts-contrats-eng.html';
-	public $baseUrl = 'http://www.ssc-spc.gc.ca/';
-	public $ownerAcronym = 'ssc';
+    public $indexUrl = 'http://www.ssc-spc.gc.ca/pages/contracts-contrats-eng.html';
+    public $baseUrl = 'http://www.ssc-spc.gc.ca/';
+    public $ownerAcronym = 'ssc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@id='wb-main-in']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@id='wb-main-in']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@id='wb-main-in']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@id='wb-main-in']//table//td//a/@href";
 
-	/*
+    /*
 	public function quarterToContractUrlTransform($contractUrl) {
 		return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
 	}
@@ -27,90 +28,89 @@ class SscHandler extends DepartmentHandler {
 	}*/
 
 
-	// Ignore the latest quarter that uses "open.canada.ca" as a link instead.
-	// We'll need to retrieve those from the actual dataset.
-	public function filterQuarterUrls($quarterUrls) {
+    // Ignore the latest quarter that uses "open.canada.ca" as a link instead.
+    // We'll need to retrieve those from the actual dataset.
+    public function filterQuarterUrls($quarterUrls)
+    {
 
-		// Remove the new entries with "open.canada.ca"
-		$quarterUrls = array_filter($quarterUrls, function($url) {
-			if(strpos($url, 'open.canada.ca') !== false) {
-				return false;
-			}
-			return true;
-		});
+        // Remove the new entries with "open.canada.ca"
+        $quarterUrls = array_filter($quarterUrls, function ($url) {
+            if (strpos($url, 'open.canada.ca') !== false) {
+                return false;
+            }
+            return true;
+        });
 
-		return $quarterUrls;
-	}
+        return $quarterUrls;
+    }
 
 
-	public $contractContentSubsetXpath = "//div[@id='wb-main-in']";
+    public $contractContentSubsetXpath = "//div[@id='wb-main-in']";
 
-	public function fiscalYearAndQuarterFromTitle($quarterHtml, $output ='year') {
+    public function fiscalYearAndQuarterFromTitle($quarterHtml, $output = 'year')
+    {
 
-		// Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
+        // Somewhat confusingly, IRCC indexes quarters by calendar year instead of by fiscal year.
 
-		$quarterIndex = [
-			'Fourth Quarter' => 4,
-			'First Quarter' => 1,
-			'Second Quarter' => 2,
-			'Third Quarter' => 3,
-		];
+        $quarterIndex = [
+            'Fourth Quarter' => 4,
+            'First Quarter' => 1,
+            'Second Quarter' => 2,
+            'Third Quarter' => 3,
+        ];
 
-		$fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
-		$fiscalQuarter = '';
+        $fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+        $fiscalQuarter = '';
 
 
 // \w
-		$title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
+        $title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
 
-		// Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
-		foreach($quarterIndex as $quarterLabel => $quarterKey) {
-			if(strpos($title, $quarterLabel) !== false) {
-				$fiscalQuarter = $quarterKey;
-				break;
-			}
-		}
+        // Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
+        foreach ($quarterIndex as $quarterLabel => $quarterKey) {
+            if (strpos($title, $quarterLabel) !== false) {
+                $fiscalQuarter = $quarterKey;
+                break;
+            }
+        }
 
-		if($output == 'year') {
-			return $fiscalYear;
-		}
-		else {
-			return $fiscalQuarter;
-		}
+        if ($output == 'year') {
+            return $fiscalYear;
+        } else {
+            return $fiscalQuarter;
+        }
+    }
 
-	}
+    public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl) {
+        return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'year');
+    }
 
-		return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'year');
+    public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	}
+        return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'quarter');
+    }
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl) {
+    public function parseHtml($html)
+    {
 
-		return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'quarter');
+        $keyArray = [
+            'vendorName' => 'Vendor Name',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Contract Date',
+            'description' => 'Description',
+            'extraDescription' => 'Detailed Description',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period',
+            'deliveryDate' => 'Delivery Date',
+            'originalValue' => 'Original Contract Value',
+            'contractValue' => 'Contract Value',
+            'comments' => 'Comments',
+        ];
 
-	}
-
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Contract Date',
-			'description' => 'Description',
-			'extraDescription' => 'Detailed Description',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period',
-			'deliveryDate' => 'Delivery Date',
-			'originalValue' => 'Original Contract Value',
-			'contractValue' => 'Contract Value',
-			'comments' => 'Comments',
-		];
-
-		return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/StatsHandler.php
+++ b/app/DepartmentHandlers/StatsHandler.php
@@ -4,20 +4,21 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class StatsHandler extends DepartmentHandler {
+class StatsHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'https://www.statcan.gc.ca/eng/about/contract/report';
-	public $baseUrl = 'https://www.statcan.gc.ca/';
-	public $ownerAcronym = 'stats';
+    public $indexUrl = 'https://www.statcan.gc.ca/eng/about/contract/report';
+    public $baseUrl = 'https://www.statcan.gc.ca/';
+    public $ownerAcronym = 'stats';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//div[@role='main']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//div[@role='main']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//div[@role='main']//table//td//a/@href";
+    public $quarterToContractXpath = "//div[@role='main']//table//td//a/@href";
 
-	/*
+    /*
 	public function quarterToContractUrlTransform($contractUrl) {
 		return "http://www.cic.gc.ca/disclosure-divulgation/" . $contractUrl;
 	}
@@ -27,88 +28,87 @@ class StatsHandler extends DepartmentHandler {
 	}*/
 
 
-	// Ignore the latest quarter that uses "open.canada.ca" as a link instead.
-	// We'll need to retrieve those from the actual dataset.
-	public function filterQuarterUrls($quarterUrls) {
+    // Ignore the latest quarter that uses "open.canada.ca" as a link instead.
+    // We'll need to retrieve those from the actual dataset.
+    public function filterQuarterUrls($quarterUrls)
+    {
 
-		// Remove the new entries with "open.canada.ca"
-		$quarterUrls = array_filter($quarterUrls, function($url) {
-			if(strpos($url, 'open.canada.ca') !== false) {
-				return false;
-			}
-			return true;
-		});
+        // Remove the new entries with "open.canada.ca"
+        $quarterUrls = array_filter($quarterUrls, function ($url) {
+            if (strpos($url, 'open.canada.ca') !== false) {
+                return false;
+            }
+            return true;
+        });
 
-		return $quarterUrls;
-	}
+        return $quarterUrls;
+    }
 
 
-	public $contractContentSubsetXpath = "//div[@role='main']";
+    public $contractContentSubsetXpath = "//div[@role='main']";
 
-	public function fiscalYearAndQuarterFromTitle($quarterHtml, $output ='year') {
+    public function fiscalYearAndQuarterFromTitle($quarterHtml, $output = 'year')
+    {
 
-		$quarterIndex = [
-			'Fourth quarter' => 4,
-			'First quarter' => 1,
-			'Second quarter' => 2,
-			'Third quarter' => 3,
-		];
+        $quarterIndex = [
+            'Fourth quarter' => 4,
+            'First quarter' => 1,
+            'Second quarter' => 2,
+            'Third quarter' => 3,
+        ];
 
-		$fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
-		$fiscalQuarter = '';
+        $fiscalYear = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/([0-9]{4})/');
+        $fiscalQuarter = '';
 
 
 // \w
-		$title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
+        $title = Helpers::xpathRegexComboSearch($quarterHtml, "//h1[@id='wb-cont']", '/(.*)/');
 
-		// Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
-		foreach($quarterIndex as $quarterLabel => $quarterKey) {
-			if(strpos($title, $quarterLabel) !== false) {
-				$fiscalQuarter = $quarterKey;
-				break;
-			}
-		}
+        // Try to find one of the text labels in the title element, and match the Q1, Q2, etc. value:
+        foreach ($quarterIndex as $quarterLabel => $quarterKey) {
+            if (strpos($title, $quarterLabel) !== false) {
+                $fiscalQuarter = $quarterKey;
+                break;
+            }
+        }
 
-		if($output == 'year') {
-			return $fiscalYear;
-		}
-		else {
-			return $fiscalQuarter;
-		}
+        if ($output == 'year') {
+            return $fiscalYear;
+        } else {
+            return $fiscalQuarter;
+        }
+    }
 
-	}
+    public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	public function fiscalYearFromQuarterPage($quarterHtml, $quarterUrl) {
+        return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'year');
+    }
 
-		return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'year');
+    public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl)
+    {
 
-	}
+        return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'quarter');
+    }
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml, $quarterUrl) {
+    public function parseHtml($html)
+    {
 
-		return $this->fiscalYearAndQuarterFromTitle($quarterHtml, 'quarter');
+        $keyArray = [
+            'vendorName' => 'Vendor',
+            'referenceNumber' => 'Reference Number',
+            'contractDate' => 'Contract Date',
+            'description' => 'Description of work',
+            'extraDescription' => 'Detailed Description',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period',
+            'deliveryDate' => 'Delivery Date',
+            'originalValue' => 'Original Contract Value',
+            'contractValue' => 'Contract Value',
+            'comments' => 'Comments',
+        ];
 
-	}
-
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor',
-			'referenceNumber' => 'Reference Number',
-			'contractDate' => 'Contract Date',
-			'description' => 'Description of work',
-			'extraDescription' => 'Detailed Description',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period',
-			'deliveryDate' => 'Delivery Date',
-			'originalValue' => 'Original Contract Value',
-			'contractValue' => 'Contract Value',
-			'comments' => 'Comments',
-		];
-
-		return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/TbsHandler.php
+++ b/app/DepartmentHandlers/TbsHandler.php
@@ -4,66 +4,68 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class TbsHandler extends DepartmentHandler {
+class TbsHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://www.tbs-sct.gc.ca/scripts/contracts-contrats/reports-rapports-eng.asp';
-	public $baseUrl = 'http://www.tbs-sct.gc.ca/';
-	public $ownerAcronym = 'tbs';
+    public $indexUrl = 'http://www.tbs-sct.gc.ca/scripts/contracts-contrats/reports-rapports-eng.asp';
+    public $baseUrl = 'http://www.tbs-sct.gc.ca/';
+    public $ownerAcronym = 'tbs';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//main//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//main//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//main//table//td//a/@href";
+    public $quarterToContractXpath = "//main//table//td//a/@href";
 
-	
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://www.tbs-sct.gc.ca/scripts/contracts-contrats/" . $contractUrl;
-	}
-	
+    
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://www.tbs-sct.gc.ca/scripts/contracts-contrats/" . $contractUrl;
+    }
+    
 
-	
-	public function indexToQuarterUrlTransform($url) {
-		return "http://www.tbs-sct.gc.ca/scripts/contracts-contrats/" . $url;
-	}
-	
+    
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://www.tbs-sct.gc.ca/scripts/contracts-contrats/" . $url;
+    }
+    
 
-	public $contractContentSubsetXpath = "//main";
+    public $contractContentSubsetXpath = "//main";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
+        // <h1 id="wb-cont" property="name" class="page-header mrgn-tp-md">2016-2017, 3rd quarter (1 October - 31 December 2016)</h1>
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h1", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h1", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h1", '/([0-9])[a-z]/');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//main//h1", '/([0-9])[a-z]/');
+    public function parseHtml($html)
+    {
 
-	}
+        $keyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Detailed Description',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Original Contract Value:',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
 
-	public function parseHtml($html) {
-
-		$keyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Detailed Description',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Original Contract Value:',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
-
-		return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th", "//table//td", ' to ', $keyArray);
+    }
 }

--- a/app/DepartmentHandlers/TcHandler.php
+++ b/app/DepartmentHandlers/TcHandler.php
@@ -4,51 +4,53 @@ namespace App\DepartmentHandlers;
 use App\DepartmentHandler;
 use App\Helpers;
 
-class TcHandler extends DepartmentHandler {
+class TcHandler extends DepartmentHandler
+{
 
-	public $indexUrl = 'http://wwwapps.tc.gc.ca/Corp-Serv-Gen/2/PDC-DPC/contract/reports.aspx';
-	public $baseUrl = 'http://wwwapps.tc.gc.ca/';
-	public $ownerAcronym = 'tc';
+    public $indexUrl = 'http://wwwapps.tc.gc.ca/Corp-Serv-Gen/2/PDC-DPC/contract/reports.aspx';
+    public $baseUrl = 'http://wwwapps.tc.gc.ca/';
+    public $ownerAcronym = 'tc';
 
-	// From the index page, list all the "quarter" URLs
-	public $indexToQuarterXpath = "//form[@id='pageForm']//ul/li/a/@href";
+    // From the index page, list all the "quarter" URLs
+    public $indexToQuarterXpath = "//form[@id='pageForm']//ul/li/a/@href";
 
-	public $multiPage = 0;
+    public $multiPage = 0;
 
-	public $quarterToContractXpath = "//form[@id='pageForm']//table//td//a/@href";
+    public $quarterToContractXpath = "//form[@id='pageForm']//table//td//a/@href";
 
-	
-	public function quarterToContractUrlTransform($contractUrl) {
-		return "http://wwwapps.tc.gc.ca/Corp-Serv-Gen/2/PDC-DPC/contract/" . $contractUrl;
-	}
-	
+    
+    public function quarterToContractUrlTransform($contractUrl)
+    {
+        return "http://wwwapps.tc.gc.ca/Corp-Serv-Gen/2/PDC-DPC/contract/" . $contractUrl;
+    }
+    
 
-	
-	public function indexToQuarterUrlTransform($url) {
-		return "http://wwwapps.tc.gc.ca/Corp-Serv-Gen/2/PDC-DPC/contract/" . $url;
-	}
-	
+    
+    public function indexToQuarterUrlTransform($url)
+    {
+        return "http://wwwapps.tc.gc.ca/Corp-Serv-Gen/2/PDC-DPC/contract/" . $url;
+    }
+    
 
-	public $contractContentSubsetXpath = "//form[@id='pageForm']";
+    public $contractContentSubsetXpath = "//form[@id='pageForm']";
 
-	public function fiscalYearFromQuarterPage($quarterHtml) {
+    public function fiscalYearFromQuarterPage($quarterHtml)
+    {
 
-		// //*[@id="pageForm"]/p[2]/strong
+        // //*[@id="pageForm"]/p[2]/strong
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//form[@id='pageForm']/p[2]/strong", '/([0-9]{4})/');
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//form[@id='pageForm']/p[2]/strong", '/([0-9]{4})/');
+    }
 
-	}
+    public function fiscalQuarterFromQuarterPage($quarterHtml)
+    {
 
-	public function fiscalQuarterFromQuarterPage($quarterHtml) {
+        return Helpers::xpathRegexComboSearch($quarterHtml, "//form[@id='pageForm']/p[2]/strong", '/([0-9])</');
+    }
 
-		return Helpers::xpathRegexComboSearch($quarterHtml, "//form[@id='pageForm']/p[2]/strong", '/([0-9])</');
+    public function parseHtml($html)
+    {
 
-	}
-
-	public function parseHtml($html) {
-
-		return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ');
-
-	}
-
+        return Helpers::genericXpathParser($html, "//table//th[@scope='row']", "//table//td", ' to ');
+    }
 }

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -3,565 +3,554 @@ namespace App;
 
 use XPathSelector\Selector;
 
-class Helpers {
-
-	public static function cleanupDate($dateInput, $printErrors = 1) {
-
-		// 11/1/2013
-		$time = strtotime($dateInput);
-		if($time) {
-			return $time;
-		}
-		else {
-			// Try doing the month switch and see if that helps:
-			if($dateInput) {
-				$time = strtotime(self::switchMonthsAndDays($dateInput, $printErrors));
-				if($time) {
-
-					if($printErrors) {
-						echo "Switched months and days for: '$dateInput'\n";
-					}
-					return $time;
-				}
-				else {
-					if($printErrors) {
-						echo "Date cleanup error: '$dateInput'\n";
-					}
-					
-				}
-			}
-			// If there's no $dateInput at all, don't print an error:
-			return false;
-		}
-		
-
-
-	}
-
-	// Should transition to yearFromDate (below) which is more reliable:
-	public static function dateToYear($dateInput) {
-
-		$time = self::cleanupDate($dateInput);
-		if($time) {
-			return date('Y', $time);
-		}
-		else {
-			return false;
-		}
-
-	}
-
-	// Use a regex for the same thing as above, but more reliably:
-	public static function yearFromDate($dateInput) {
-
-		// ([1-2][0-9][0-9][0-9])
-
-		$matches = [];
-		$pattern = '/([1-2][0-9][0-9][0-9])/';
-
-		$year = preg_match($pattern, $dateInput, $matches);
-		if($matches) {
-			return $matches[1];
-		}
-
-		return false;
-
-	}
-
-	public static function fixDndDate($dateInput) {
-
-		$year = self::yearFromDate($dateInput);
-
-		// Default backup values
-		$month = '01';
-		$day = '01';
-
-		$matches = [];
-		$pattern = '/([0-9]+)-/';
-
-		preg_match_all($pattern, $dateInput, $matches, PREG_SET_ORDER);
-
-		if($matches) {
-			if(isset($matches[0][1])) {
-				$day = str_pad($matches[0][1], 2, '0', STR_PAD_LEFT);
-			}
-			if(isset($matches[1][1])) {
-				$month = str_pad($matches[1][1], 2, '0', STR_PAD_LEFT);
-			}
-		}
-
-		return $year . '-' . $month . '-' . $day;
-
-	}
-
-	// Uses a series of regular expressions to cleanup bad date data
-	// This often probably gets months and days mixed-up, but that's okay.
-	// We're going for nearest year in this case.
-	public static function regDateCleanup($dateInput) {
-
-		if(! $dateInput) {
-			return false;
-		}
-
-		$year = null;
-		$month = null;
-		$day = null;
-
-		$yearMatches = [];
-		$pattern = '/([1-2][0-9][0-9][0-9])/';
-		preg_match($pattern, $dateInput, $yearMatches);
-
-		if($yearMatches) {
-			$year = $yearMatches[1];
-		}
-
-		$monthMatches = [];
-		$pattern = '/([0-1][0-2])/';
-		preg_match($pattern, str_replace($year, '', $dateInput), $monthMatches);
-
-		if($monthMatches) {
-			$month = $monthMatches[1];
-		}
-
-		$dayMatches = [];
-		$pattern = '/([0-3][0-9])/';
-		preg_match($pattern, str_replace([$year, $month], '', $dateInput), $dayMatches);
-
-		if($dayMatches) {
-			$day = $dayMatches[1];
-		}
-
-		if(! $month) {
-			$month = '01';
-		}
-		if(! $day) {
-			$day = '01';
-		}
-
-		if($year) {
-			return $year . '-' . $month . '-' . $day;
-		}
-		else {
-			echo "Could not parse '$dateInput'\n";
-			return false;
-		}
-		
-	}
-
-	// Thanks to
-	// https://stackoverflow.com/a/6059008/756641
-	// Usage
-	// $str = unicodeString("\u1000");
-	public static function unicodeString($str, $encoding=null) {
-	    if (is_null($encoding)) $encoding = ini_get('mbstring.internal_encoding');
-	    return preg_replace_callback('/\\\\u([0-9a-fA-F]{4})/u', function($match) use ($encoding) {
-	        return mb_convert_encoding(pack('H*', $match[1]), $encoding, 'UTF-16BE');
-	    }, $str);
-	}
-
-	public static function cleanupContractValue($input) {
-
-		$output = str_replace(['$', ',', ' '], '', $input);
-		return floatval($output);
-
-	}
-
-	public static function cleanHtmlValue($value) {
-
-		$value = str_replace(['&nbsp;', '&amp;', '&AMP;'], [' ', '&', '&'], $value);
-		
-		// Clean up any pesky unicode characters
-		// In the case of \u00A0, it's a non-breaking space:
-		// Not exactly sure why the Â shows up though...
-		$value = str_replace([self::unicodeString("\u00A0"), ' ', 'Â'], '', $value);
-
-		$value = trim(strip_tags($value));
-		return $value;
-
-	}
-
-	public static function cleanLabelText($label) {
-
-		// Thanks to
-		// https://stackoverflow.com/a/11321058/756641
-		$label = preg_replace('/[^\da-z]/i', '', strtolower($label));
-
-		return trim($label);
-
-	}
-
-	public static function removeLinebreaks($input) {
-
-		$output = str_replace(["\n", "\r", "\t"], ' ', $input);
-		return trim($output);
-
-	}
-
-	public static function switchMonthsAndDays($dateString, $printErrors = 1) {
-		// Takes a YYYY-DD-MM (whyyyy, CSA?)
-		// and changes it to YYYY-MM-DD
-
-		$split = explode('-', $dateString);
-		if(count($split) == 3) {
-			return $split[0] . '-' . $split[2] . '-' . $split[1];
-		}
-		else {
-			if($printErrors) {
-				echo "Error: could not switchMonthsAndDays for '$dateString'\n";
-			}
-			
-			return false;
-		}
-		
-
-	}
-
-	public static function stringBetween($start, $end, $string) {
-
-		if(! $string) {
-			return '';
-		}
-
-		$split = explode($start, $string);
-		return explode($end, $split[1])[0];
-
-	}
-
-	public static function cleanText($inputText) {
-
-		// return self::cleanNonAsciiCharactersInString($inputText);
-		return iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $inputText);
-
-	}
-
-	// Thanks to,
-	// http://stackoverflow.com/a/24925209/756641
-	public static function cleanNonAsciiCharactersInString($orig_text) {
-
-	    $text = $orig_text;
-
-	    // Single letters
-	    $text = preg_replace("/[∂άαáàâãªä]/u",      "a", $text);
-	    $text = preg_replace("/[∆лДΛдАÁÀÂÃÄ]/u",     "A", $text);
-	    $text = preg_replace("/[ЂЪЬБъь]/u",           "b", $text);
-	    $text = preg_replace("/[βвВ]/u",            "B", $text);
-	    $text = preg_replace("/[çς©с]/u",            "c", $text);
-	    $text = preg_replace("/[ÇС]/u",              "C", $text);        
-	    $text = preg_replace("/[δ]/u",             "d", $text);
-	    $text = preg_replace("/[éèêëέëèεе℮ёєэЭ]/u", "e", $text);
-	    $text = preg_replace("/[ÉÈÊË€ξЄ€Е∑]/u",     "E", $text);
-	    $text = preg_replace("/[₣]/u",               "F", $text);
-	    $text = preg_replace("/[НнЊњ]/u",           "H", $text);
-	    $text = preg_replace("/[ђћЋ]/u",            "h", $text);
-	    $text = preg_replace("/[ÍÌÎÏ]/u",           "I", $text);
-	    $text = preg_replace("/[íìîïιίϊі]/u",       "i", $text);
-	    $text = preg_replace("/[Јј]/u",             "j", $text);
-	    $text = preg_replace("/[ΚЌК]/u",            'K', $text);
-	    $text = preg_replace("/[ќк]/u",             'k', $text);
-	    $text = preg_replace("/[ℓ∟]/u",             'l', $text);
-	    $text = preg_replace("/[Мм]/u",             "M", $text);
-	    $text = preg_replace("/[ñηήηπⁿ]/u",            "n", $text);
-	    $text = preg_replace("/[Ñ∏пПИЙийΝЛ]/u",       "N", $text);
-	    $text = preg_replace("/[óòôõºöοФσόо]/u", "o", $text);
-	    $text = preg_replace("/[ÓÒÔÕÖθΩθОΩ]/u",     "O", $text);
-	    $text = preg_replace("/[ρφрРф]/u",          "p", $text);
-	    $text = preg_replace("/[®яЯ]/u",              "R", $text); 
-	    $text = preg_replace("/[ГЃгѓ]/u",              "r", $text); 
-	    $text = preg_replace("/[Ѕ]/u",              "S", $text);
-	    $text = preg_replace("/[ѕ]/u",              "s", $text);
-	    $text = preg_replace("/[Тт]/u",              "T", $text);
-	    $text = preg_replace("/[τ†‡]/u",              "t", $text);
-	    $text = preg_replace("/[úùûüџμΰµυϋύ]/u",     "u", $text);
-	    $text = preg_replace("/[√]/u",               "v", $text);
-	    $text = preg_replace("/[ÚÙÛÜЏЦц]/u",         "U", $text);
-	    $text = preg_replace("/[Ψψωώẅẃẁщш]/u",      "w", $text);
-	    $text = preg_replace("/[ẀẄẂШЩ]/u",          "W", $text);
-	    $text = preg_replace("/[ΧχЖХж]/u",          "x", $text);
-	    $text = preg_replace("/[ỲΫ¥]/u",           "Y", $text);
-	    $text = preg_replace("/[ỳγўЎУуч]/u",       "y", $text);
-	    $text = preg_replace("/[ζ]/u",              "Z", $text);
-
-	    // Punctuation
-	    $text = preg_replace("/[‚‚]/u", ",", $text);        
-	    $text = preg_replace("/[`‛′’‘]/u", "'", $text);
-	    $text = preg_replace("/[″“”«»„]/u", '"', $text);
-	    $text = preg_replace("/[—–―−–‾⌐─↔→←]/u", '-', $text);
-	    $text = preg_replace("/[  ]/u", ' ', $text);
-
-	    $text = str_replace("…", "...", $text);
-	    $text = str_replace("≠", "!=", $text);
-	    $text = str_replace("≤", "<=", $text);
-	    $text = str_replace("≥", ">=", $text);
-	    $text = preg_replace("/[‗≈≡]/u", "=", $text);
-
-
-	    // Exciting combinations    
-	    $text = str_replace("ыЫ", "bl", $text);
-	    $text = str_replace("℅", "c/o", $text);
-	    $text = str_replace("₧", "Pts", $text);
-	    $text = str_replace("™", "tm", $text);
-	    $text = str_replace("№", "No", $text);        
-	    $text = str_replace("Ч", "4", $text);                
-	    $text = str_replace("‰", "%", $text);
-	    $text = preg_replace("/[∙•]/u", "*", $text);
-	    $text = str_replace("‹", "<", $text);
-	    $text = str_replace("›", ">", $text);
-	    $text = str_replace("‼", "!!", $text);
-	    $text = str_replace("⁄", "/", $text);
-	    $text = str_replace("∕", "/", $text);
-	    $text = str_replace("⅞", "7/8", $text);
-	    $text = str_replace("⅝", "5/8", $text);
-	    $text = str_replace("⅜", "3/8", $text);
-	    $text = str_replace("⅛", "1/8", $text);        
-	    $text = preg_replace("/[‰]/u", "%", $text);
-	    $text = preg_replace("/[Љљ]/u", "Ab", $text);
-	    $text = preg_replace("/[Юю]/u", "IO", $text);
-	    $text = preg_replace("/[ﬁﬂ]/u", "fi", $text);
-	    $text = preg_replace("/[зЗ]/u", "3", $text); 
-	    $text = str_replace("£", "(pounds)", $text);
-	    $text = str_replace("₤", "(lira)", $text);
-	    $text = preg_replace("/[‰]/u", "%", $text);
-	    $text = preg_replace("/[↨↕↓↑│]/u", "|", $text);
-	    $text = preg_replace("/[∞∩∫⌂⌠⌡]/u", "", $text);
-
-
-	    //2) Translation CP1252.
-	    $trans = get_html_translation_table(HTML_ENTITIES);
-	    $trans['f'] = '&fnof;';    // Latin Small Letter F With Hook
-	    $trans['-'] = array(
-	        '&hellip;',     // Horizontal Ellipsis
-	        '&tilde;',      // Small Tilde
-	        '&ndash;'       // Dash
-	        );
-	    $trans["+"] = '&dagger;';    // Dagger
-	    $trans['#'] = '&Dagger;';    // Double Dagger         
-	    $trans['M'] = '&permil;';    // Per Mille Sign
-	    $trans['S'] = '&Scaron;';    // Latin Capital Letter S With Caron        
-	    $trans['OE'] = '&OElig;';    // Latin Capital Ligature OE
-	    $trans["'"] = array(
-	        '&lsquo;',  // Left Single Quotation Mark
-	        '&rsquo;',  // Right Single Quotation Mark
-	        '&rsaquo;', // Single Right-Pointing Angle Quotation Mark
-	        '&sbquo;',  // Single Low-9 Quotation Mark
-	        '&circ;',   // Modifier Letter Circumflex Accent
-	        '&lsaquo;'  // Single Left-Pointing Angle Quotation Mark
-	        );
-
-	    $trans['"'] = array(
-	        '&ldquo;',  // Left Double Quotation Mark
-	        '&rdquo;',  // Right Double Quotation Mark
-	        '&bdquo;',  // Double Low-9 Quotation Mark
-	        );
-
-	    $trans['*'] = '&bull;';    // Bullet
-	    $trans['n'] = '&ndash;';    // En Dash
-	    $trans['m'] = '&mdash;';    // Em Dash        
-	    $trans['tm'] = '&trade;';    // Trade Mark Sign
-	    $trans['s'] = '&scaron;';    // Latin Small Letter S With Caron
-	    $trans['oe'] = '&oelig;';    // Latin Small Ligature OE
-	    $trans['Y'] = '&Yuml;';    // Latin Capital Letter Y With Diaeresis
-	    $trans['euro'] = '&euro;';    // euro currency symbol
-	    ksort($trans);
-
-	    foreach ($trans as $k => $v) {
-	        $text = str_replace($v, $k, $text);
-	    }
-
-	    // 3) remove <p>, <br/> ...
-	    $text = strip_tags($text);
-
-	    // 4) &amp; => & &quot; => '
-	    $text = html_entity_decode($text);
-
-
-	    // transliterate
-	    // if (function_exists('iconv')) {
-	    // $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
-	    // }
-
-	    // remove non ascii characters
-	    // $text =  preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $text);      
-
-	    return $text;
-	}
-
-
-	public static function dateIsWithinYearRange($startYear, $endYear, $targetYear) {
-
-		if($startYear <= $targetYear && $targetYear <= $endYear) {
-			return true;
-		}
-		else {
-			return false;
-		}
-
-	}
-
-
-	// $periodSplitString = " to "
-	public static function genericXpathParser($html, $keyXpath, $valueXpath, $periodSplitString, $keyArray = []) {
-
-		$values = [];
-		$defaultKeyArray = [
-			'vendorName' => 'Vendor Name:',
-			'referenceNumber' => 'Reference Number:',
-			'contractDate' => 'Contract Date:',
-			'description' => 'Description of work:',
-			'extraDescription' => 'Description (more details):',
-			'contractPeriodStart' => '',
-			'contractPeriodEnd' => '',
-			'contractPeriodRange' => 'Contract Period:',
-			'deliveryDate' => 'Delivery Date:',
-			'originalValue' => 'Original Contract Value:',
-			'contractValue' => 'Contract Value:',
-			'comments' => 'Comments:',
-		];
-
-		if($keyArray == []) {
-			$keyArray = $defaultKeyArray;
-		}
-
-		$cleanKeys = [];
-		foreach($keyArray as $key => $label) {
-			$cleanKeys[$key] = Helpers::cleanLabelText($label);
-		}
-
-		$labelToKey = array_flip($cleanKeys);
-
-		$xs = Selector::loadHTML($html);
-
-		// Extracts the keys (from the <th> tags) in order
-		$keyNodes = $xs->findAll($keyXpath)->map(function ($node, $index) {
-			return (string)$node;
-		});
-
-		// Extracts the values (from the <td> tags) in hopefully the same order:
-		$valueNodes = $xs->findAll($valueXpath)->map(function ($node, $index) {
-			return (string)$node;
-		});
-
-		$keys = [];
-
-		// var_dump($keyNodes);
-		// var_dump($valueNodes);
-
-		foreach($keyNodes as $index => $keyNode) {
-
-			$keyNode = Helpers::cleanLabelText($keyNode);
-
-			if(isset($labelToKey[$keyNode]) && $labelToKey[$keyNode] && isset($valueNodes[$index])) {
-				$values[$labelToKey[$keyNode]] = Helpers::cleanHtmlValue($valueNodes[$index]);
-			}
-			
-		}
-
-		// var_dump($values);
-		// exit();
-
-		// Change the "to" range into start and end values:
-		if(isset($values['contractPeriodRange']) && $values['contractPeriodRange']) {
-			$split = explode($periodSplitString, $values['contractPeriodRange']);
-
-			if(isset($split[0]) && isset($split[1])) {
-				$values['contractPeriodStart'] = trim($split[0]);
-				$values['contractPeriodEnd'] = trim($split[1]);
-			}
-		}
-
-		// var_dump($values);
-		return $values;
-
-	}
-
-	public static function xpathRegexComboSearch($html, $xpathQuery, $regexPattern = '') {
-
-		$output = '';
-
-		$xs = Selector::loadHTML($html);
-		$text = $xs->find($xpathQuery)->innerHTML();
-
-		if(! $regexPattern) {
-			return $text;
-		}
-
-		$matches = [];
-		$pattern = $regexPattern;
-
-		preg_match($pattern, $text, $matches);
-		if($matches) {
-			$output = $matches[1];
-		}
-
-		return $output;
-
-	}
-
-	// Just in case there are any changes we want to make to all contract HTML files before they're run through the parser script:
-	public static function initialSourceTransform($html, $acronym) {
-		
-		// Since <br>'s don't seem to be used in any of the actual table structures, this way we can avoid text being stuck together when tags are stripped from text content:
-		$html = str_replace(['<br>'], [' '], $html);
-
-		return $html;
-	}
-
-
-	// Contract clean-up of missing values etc.:
-	public static function checkContractValues(&$contract, $vendorData = []) {
-
-		// In some cases, entries are missing a contract period start, but do have a contract date. If so, use that instead:
-		if(! $contract['startYear']) {
-			// if($contract['deliveryDate']) {
-			// 	$contract['startYear'] = Helpers::yearFromDate($contract['deliveryDate']);
-			// }
-			// else {
-			// 	$contract['startYear'] = Helpers::yearFromDate($contract['contractDate']);
-			// }
-
-			$contract['startYear'] = Helpers::yearFromDate($contract['contractDate']);
-		}
-
-		// If there's no end year, assume that it's the same as the start year:
-		if(! $contract['endYear']) {
-			if($contract['deliveryDate']) {
-				$contract['endYear'] = Helpers::yearFromDate($contract['deliveryDate']);
-			}
-			else {
-				$contract['endYear'] = $contract['startYear'];
-			}
-			
-		}
-
-		// If there's no original contract value, use the current value:
-		if(! $contract['originalValue']) {
-			$contract['originalValue'] = $contract['contractValue'];
-		}
-
-
-		$contract['yearsDuration'] = abs($contract['endYear'] - $contract['startYear']) + 1;
-		$contract['valuePerYear'] = $contract['contractValue'] / $contract['yearsDuration'];
-
-		// Find the consolidated vendor name:
-		if($vendorData) {
-			$contract['vendorClean'] = $vendorData->consolidateVendorNames($contract['vendorName']);
-		}
-		
-
-
-		// Remove any linebreaks etc.
-		// vendorName
-		// referenceNumber
-		// description
-		// comments
-		foreach(['vendorName', 'referenceNumber', 'description', 'comments', 'extraDescription'] as $textField) {
-			if(isset($contract[$textField]) && $contract[$textField]) {
-				$contract[$textField] = self::removeLinebreaks($contract[$textField]);
-			}
-
-		}
-
-
-	}
+class Helpers
+{
+
+    public static function cleanupDate($dateInput, $printErrors = 1)
+    {
+
+        // 11/1/2013
+        $time = strtotime($dateInput);
+        if ($time) {
+            return $time;
+        } else {
+            // Try doing the month switch and see if that helps:
+            if ($dateInput) {
+                $time = strtotime(self::switchMonthsAndDays($dateInput, $printErrors));
+                if ($time) {
+                    if ($printErrors) {
+                        echo "Switched months and days for: '$dateInput'\n";
+                    }
+                    return $time;
+                } else {
+                    if ($printErrors) {
+                        echo "Date cleanup error: '$dateInput'\n";
+                    }
+                }
+            }
+            // If there's no $dateInput at all, don't print an error:
+            return false;
+        }
+    }
+
+    // Should transition to yearFromDate (below) which is more reliable:
+    public static function dateToYear($dateInput)
+    {
+
+        $time = self::cleanupDate($dateInput);
+        if ($time) {
+            return date('Y', $time);
+        } else {
+            return false;
+        }
+    }
+
+    // Use a regex for the same thing as above, but more reliably:
+    public static function yearFromDate($dateInput)
+    {
+
+        // ([1-2][0-9][0-9][0-9])
+
+        $matches = [];
+        $pattern = '/([1-2][0-9][0-9][0-9])/';
+
+        $year = preg_match($pattern, $dateInput, $matches);
+        if ($matches) {
+            return $matches[1];
+        }
+
+        return false;
+    }
+
+    public static function fixDndDate($dateInput)
+    {
+
+        $year = self::yearFromDate($dateInput);
+
+        // Default backup values
+        $month = '01';
+        $day = '01';
+
+        $matches = [];
+        $pattern = '/([0-9]+)-/';
+
+        preg_match_all($pattern, $dateInput, $matches, PREG_SET_ORDER);
+
+        if ($matches) {
+            if (isset($matches[0][1])) {
+                $day = str_pad($matches[0][1], 2, '0', STR_PAD_LEFT);
+            }
+            if (isset($matches[1][1])) {
+                $month = str_pad($matches[1][1], 2, '0', STR_PAD_LEFT);
+            }
+        }
+
+        return $year . '-' . $month . '-' . $day;
+    }
+
+    // Uses a series of regular expressions to cleanup bad date data
+    // This often probably gets months and days mixed-up, but that's okay.
+    // We're going for nearest year in this case.
+    public static function regDateCleanup($dateInput)
+    {
+
+        if (! $dateInput) {
+            return false;
+        }
+
+        $year = null;
+        $month = null;
+        $day = null;
+
+        $yearMatches = [];
+        $pattern = '/([1-2][0-9][0-9][0-9])/';
+        preg_match($pattern, $dateInput, $yearMatches);
+
+        if ($yearMatches) {
+            $year = $yearMatches[1];
+        }
+
+        $monthMatches = [];
+        $pattern = '/([0-1][0-2])/';
+        preg_match($pattern, str_replace($year, '', $dateInput), $monthMatches);
+
+        if ($monthMatches) {
+            $month = $monthMatches[1];
+        }
+
+        $dayMatches = [];
+        $pattern = '/([0-3][0-9])/';
+        preg_match($pattern, str_replace([$year, $month], '', $dateInput), $dayMatches);
+
+        if ($dayMatches) {
+            $day = $dayMatches[1];
+        }
+
+        if (! $month) {
+            $month = '01';
+        }
+        if (! $day) {
+            $day = '01';
+        }
+
+        if ($year) {
+            return $year . '-' . $month . '-' . $day;
+        } else {
+            echo "Could not parse '$dateInput'\n";
+            return false;
+        }
+    }
+
+    // Thanks to
+    // https://stackoverflow.com/a/6059008/756641
+    // Usage
+    // $str = unicodeString("\u1000");
+    public static function unicodeString($str, $encoding = null)
+    {
+        if (is_null($encoding)) {
+            $encoding = ini_get('mbstring.internal_encoding');
+        }
+        return preg_replace_callback('/\\\\u([0-9a-fA-F]{4})/u', function ($match) use ($encoding) {
+            return mb_convert_encoding(pack('H*', $match[1]), $encoding, 'UTF-16BE');
+        }, $str);
+    }
+
+    public static function cleanupContractValue($input)
+    {
+
+        $output = str_replace(['$', ',', ' '], '', $input);
+        return floatval($output);
+    }
+
+    public static function cleanHtmlValue($value)
+    {
+
+        $value = str_replace(['&nbsp;', '&amp;', '&AMP;'], [' ', '&', '&'], $value);
+        
+        // Clean up any pesky unicode characters
+        // In the case of \u00A0, it's a non-breaking space:
+        // Not exactly sure why the Â shows up though...
+        $value = str_replace([self::unicodeString("\u00A0"), ' ', 'Â'], '', $value);
+
+        $value = trim(strip_tags($value));
+        return $value;
+    }
+
+    public static function cleanLabelText($label)
+    {
+
+        // Thanks to
+        // https://stackoverflow.com/a/11321058/756641
+        $label = preg_replace('/[^\da-z]/i', '', strtolower($label));
+
+        return trim($label);
+    }
+
+    public static function removeLinebreaks($input)
+    {
+
+        $output = str_replace(["\n", "\r", "\t"], ' ', $input);
+        return trim($output);
+    }
+
+    public static function switchMonthsAndDays($dateString, $printErrors = 1)
+    {
+        // Takes a YYYY-DD-MM (whyyyy, CSA?)
+        // and changes it to YYYY-MM-DD
+
+        $split = explode('-', $dateString);
+        if (count($split) == 3) {
+            return $split[0] . '-' . $split[2] . '-' . $split[1];
+        } else {
+            if ($printErrors) {
+                echo "Error: could not switchMonthsAndDays for '$dateString'\n";
+            }
+            
+            return false;
+        }
+    }
+
+    public static function stringBetween($start, $end, $string)
+    {
+
+        if (! $string) {
+            return '';
+        }
+
+        $split = explode($start, $string);
+        return explode($end, $split[1])[0];
+    }
+
+    public static function cleanText($inputText)
+    {
+
+        // return self::cleanNonAsciiCharactersInString($inputText);
+        return iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $inputText);
+    }
+
+    // Thanks to,
+    // http://stackoverflow.com/a/24925209/756641
+    public static function cleanNonAsciiCharactersInString($orig_text)
+    {
+
+        $text = $orig_text;
+
+        // Single letters
+        $text = preg_replace("/[∂άαáàâãªä]/u", "a", $text);
+        $text = preg_replace("/[∆лДΛдАÁÀÂÃÄ]/u", "A", $text);
+        $text = preg_replace("/[ЂЪЬБъь]/u", "b", $text);
+        $text = preg_replace("/[βвВ]/u", "B", $text);
+        $text = preg_replace("/[çς©с]/u", "c", $text);
+        $text = preg_replace("/[ÇС]/u", "C", $text);
+        $text = preg_replace("/[δ]/u", "d", $text);
+        $text = preg_replace("/[éèêëέëèεе℮ёєэЭ]/u", "e", $text);
+        $text = preg_replace("/[ÉÈÊË€ξЄ€Е∑]/u", "E", $text);
+        $text = preg_replace("/[₣]/u", "F", $text);
+        $text = preg_replace("/[НнЊњ]/u", "H", $text);
+        $text = preg_replace("/[ђћЋ]/u", "h", $text);
+        $text = preg_replace("/[ÍÌÎÏ]/u", "I", $text);
+        $text = preg_replace("/[íìîïιίϊі]/u", "i", $text);
+        $text = preg_replace("/[Јј]/u", "j", $text);
+        $text = preg_replace("/[ΚЌК]/u", 'K', $text);
+        $text = preg_replace("/[ќк]/u", 'k', $text);
+        $text = preg_replace("/[ℓ∟]/u", 'l', $text);
+        $text = preg_replace("/[Мм]/u", "M", $text);
+        $text = preg_replace("/[ñηήηπⁿ]/u", "n", $text);
+        $text = preg_replace("/[Ñ∏пПИЙийΝЛ]/u", "N", $text);
+        $text = preg_replace("/[óòôõºöοФσόо]/u", "o", $text);
+        $text = preg_replace("/[ÓÒÔÕÖθΩθОΩ]/u", "O", $text);
+        $text = preg_replace("/[ρφрРф]/u", "p", $text);
+        $text = preg_replace("/[®яЯ]/u", "R", $text);
+        $text = preg_replace("/[ГЃгѓ]/u", "r", $text);
+        $text = preg_replace("/[Ѕ]/u", "S", $text);
+        $text = preg_replace("/[ѕ]/u", "s", $text);
+        $text = preg_replace("/[Тт]/u", "T", $text);
+        $text = preg_replace("/[τ†‡]/u", "t", $text);
+        $text = preg_replace("/[úùûüџμΰµυϋύ]/u", "u", $text);
+        $text = preg_replace("/[√]/u", "v", $text);
+        $text = preg_replace("/[ÚÙÛÜЏЦц]/u", "U", $text);
+        $text = preg_replace("/[Ψψωώẅẃẁщш]/u", "w", $text);
+        $text = preg_replace("/[ẀẄẂШЩ]/u", "W", $text);
+        $text = preg_replace("/[ΧχЖХж]/u", "x", $text);
+        $text = preg_replace("/[ỲΫ¥]/u", "Y", $text);
+        $text = preg_replace("/[ỳγўЎУуч]/u", "y", $text);
+        $text = preg_replace("/[ζ]/u", "Z", $text);
+
+        // Punctuation
+        $text = preg_replace("/[‚‚]/u", ",", $text);
+        $text = preg_replace("/[`‛′’‘]/u", "'", $text);
+        $text = preg_replace("/[″“”«»„]/u", '"', $text);
+        $text = preg_replace("/[—–―−–‾⌐─↔→←]/u", '-', $text);
+        $text = preg_replace("/[  ]/u", ' ', $text);
+
+        $text = str_replace("…", "...", $text);
+        $text = str_replace("≠", "!=", $text);
+        $text = str_replace("≤", "<=", $text);
+        $text = str_replace("≥", ">=", $text);
+        $text = preg_replace("/[‗≈≡]/u", "=", $text);
+
+
+        // Exciting combinations
+        $text = str_replace("ыЫ", "bl", $text);
+        $text = str_replace("℅", "c/o", $text);
+        $text = str_replace("₧", "Pts", $text);
+        $text = str_replace("™", "tm", $text);
+        $text = str_replace("№", "No", $text);
+        $text = str_replace("Ч", "4", $text);
+        $text = str_replace("‰", "%", $text);
+        $text = preg_replace("/[∙•]/u", "*", $text);
+        $text = str_replace("‹", "<", $text);
+        $text = str_replace("›", ">", $text);
+        $text = str_replace("‼", "!!", $text);
+        $text = str_replace("⁄", "/", $text);
+        $text = str_replace("∕", "/", $text);
+        $text = str_replace("⅞", "7/8", $text);
+        $text = str_replace("⅝", "5/8", $text);
+        $text = str_replace("⅜", "3/8", $text);
+        $text = str_replace("⅛", "1/8", $text);
+        $text = preg_replace("/[‰]/u", "%", $text);
+        $text = preg_replace("/[Љљ]/u", "Ab", $text);
+        $text = preg_replace("/[Юю]/u", "IO", $text);
+        $text = preg_replace("/[ﬁﬂ]/u", "fi", $text);
+        $text = preg_replace("/[зЗ]/u", "3", $text);
+        $text = str_replace("£", "(pounds)", $text);
+        $text = str_replace("₤", "(lira)", $text);
+        $text = preg_replace("/[‰]/u", "%", $text);
+        $text = preg_replace("/[↨↕↓↑│]/u", "|", $text);
+        $text = preg_replace("/[∞∩∫⌂⌠⌡]/u", "", $text);
+
+
+        //2) Translation CP1252.
+        $trans = get_html_translation_table(HTML_ENTITIES);
+        $trans['f'] = '&fnof;';    // Latin Small Letter F With Hook
+        $trans['-'] = array(
+            '&hellip;',     // Horizontal Ellipsis
+            '&tilde;',      // Small Tilde
+            '&ndash;'       // Dash
+            );
+        $trans["+"] = '&dagger;';    // Dagger
+        $trans['#'] = '&Dagger;';    // Double Dagger
+        $trans['M'] = '&permil;';    // Per Mille Sign
+        $trans['S'] = '&Scaron;';    // Latin Capital Letter S With Caron
+        $trans['OE'] = '&OElig;';    // Latin Capital Ligature OE
+        $trans["'"] = array(
+            '&lsquo;',  // Left Single Quotation Mark
+            '&rsquo;',  // Right Single Quotation Mark
+            '&rsaquo;', // Single Right-Pointing Angle Quotation Mark
+            '&sbquo;',  // Single Low-9 Quotation Mark
+            '&circ;',   // Modifier Letter Circumflex Accent
+            '&lsaquo;'  // Single Left-Pointing Angle Quotation Mark
+            );
+
+        $trans['"'] = array(
+            '&ldquo;',  // Left Double Quotation Mark
+            '&rdquo;',  // Right Double Quotation Mark
+            '&bdquo;',  // Double Low-9 Quotation Mark
+            );
+
+        $trans['*'] = '&bull;';    // Bullet
+        $trans['n'] = '&ndash;';    // En Dash
+        $trans['m'] = '&mdash;';    // Em Dash
+        $trans['tm'] = '&trade;';    // Trade Mark Sign
+        $trans['s'] = '&scaron;';    // Latin Small Letter S With Caron
+        $trans['oe'] = '&oelig;';    // Latin Small Ligature OE
+        $trans['Y'] = '&Yuml;';    // Latin Capital Letter Y With Diaeresis
+        $trans['euro'] = '&euro;';    // euro currency symbol
+        ksort($trans);
+
+        foreach ($trans as $k => $v) {
+            $text = str_replace($v, $k, $text);
+        }
+
+        // 3) remove <p>, <br/> ...
+        $text = strip_tags($text);
+
+        // 4) &amp; => & &quot; => '
+        $text = html_entity_decode($text);
+
+
+        // transliterate
+        // if (function_exists('iconv')) {
+        // $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+        // }
+
+        // remove non ascii characters
+        // $text =  preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $text);
+
+        return $text;
+    }
+
+
+    public static function dateIsWithinYearRange($startYear, $endYear, $targetYear)
+    {
+
+        if ($startYear <= $targetYear && $targetYear <= $endYear) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    // $periodSplitString = " to "
+    public static function genericXpathParser($html, $keyXpath, $valueXpath, $periodSplitString, $keyArray = [])
+    {
+
+        $values = [];
+        $defaultKeyArray = [
+            'vendorName' => 'Vendor Name:',
+            'referenceNumber' => 'Reference Number:',
+            'contractDate' => 'Contract Date:',
+            'description' => 'Description of work:',
+            'extraDescription' => 'Description (more details):',
+            'contractPeriodStart' => '',
+            'contractPeriodEnd' => '',
+            'contractPeriodRange' => 'Contract Period:',
+            'deliveryDate' => 'Delivery Date:',
+            'originalValue' => 'Original Contract Value:',
+            'contractValue' => 'Contract Value:',
+            'comments' => 'Comments:',
+        ];
+
+        if ($keyArray == []) {
+            $keyArray = $defaultKeyArray;
+        }
+
+        $cleanKeys = [];
+        foreach ($keyArray as $key => $label) {
+            $cleanKeys[$key] = Helpers::cleanLabelText($label);
+        }
+
+        $labelToKey = array_flip($cleanKeys);
+
+        $xs = Selector::loadHTML($html);
+
+        // Extracts the keys (from the <th> tags) in order
+        $keyNodes = $xs->findAll($keyXpath)->map(function ($node, $index) {
+            return (string)$node;
+        });
+
+        // Extracts the values (from the <td> tags) in hopefully the same order:
+        $valueNodes = $xs->findAll($valueXpath)->map(function ($node, $index) {
+            return (string)$node;
+        });
+
+        $keys = [];
+
+        // var_dump($keyNodes);
+        // var_dump($valueNodes);
+
+        foreach ($keyNodes as $index => $keyNode) {
+            $keyNode = Helpers::cleanLabelText($keyNode);
+
+            if (isset($labelToKey[$keyNode]) && $labelToKey[$keyNode] && isset($valueNodes[$index])) {
+                $values[$labelToKey[$keyNode]] = Helpers::cleanHtmlValue($valueNodes[$index]);
+            }
+        }
+
+        // var_dump($values);
+        // exit();
+
+        // Change the "to" range into start and end values:
+        if (isset($values['contractPeriodRange']) && $values['contractPeriodRange']) {
+            $split = explode($periodSplitString, $values['contractPeriodRange']);
+
+            if (isset($split[0]) && isset($split[1])) {
+                $values['contractPeriodStart'] = trim($split[0]);
+                $values['contractPeriodEnd'] = trim($split[1]);
+            }
+        }
+
+        // var_dump($values);
+        return $values;
+    }
+
+    public static function xpathRegexComboSearch($html, $xpathQuery, $regexPattern = '')
+    {
+
+        $output = '';
+
+        $xs = Selector::loadHTML($html);
+        $text = $xs->find($xpathQuery)->innerHTML();
+
+        if (! $regexPattern) {
+            return $text;
+        }
+
+        $matches = [];
+        $pattern = $regexPattern;
+
+        preg_match($pattern, $text, $matches);
+        if ($matches) {
+            $output = $matches[1];
+        }
+
+        return $output;
+    }
+
+    // Just in case there are any changes we want to make to all contract HTML files before they're run through the parser script:
+    public static function initialSourceTransform($html, $acronym)
+    {
+        
+        // Since <br>'s don't seem to be used in any of the actual table structures, this way we can avoid text being stuck together when tags are stripped from text content:
+        $html = str_replace(['<br>'], [' '], $html);
+
+        return $html;
+    }
+
+
+    // Contract clean-up of missing values etc.:
+    public static function checkContractValues(&$contract, $vendorData = [])
+    {
+
+        // In some cases, entries are missing a contract period start, but do have a contract date. If so, use that instead:
+        if (! $contract['startYear']) {
+            // if($contract['deliveryDate']) {
+            // 	$contract['startYear'] = Helpers::yearFromDate($contract['deliveryDate']);
+            // }
+            // else {
+            // 	$contract['startYear'] = Helpers::yearFromDate($contract['contractDate']);
+            // }
+
+            $contract['startYear'] = Helpers::yearFromDate($contract['contractDate']);
+        }
+
+        // If there's no end year, assume that it's the same as the start year:
+        if (! $contract['endYear']) {
+            if ($contract['deliveryDate']) {
+                $contract['endYear'] = Helpers::yearFromDate($contract['deliveryDate']);
+            } else {
+                $contract['endYear'] = $contract['startYear'];
+            }
+        }
+
+        // If there's no original contract value, use the current value:
+        if (! $contract['originalValue']) {
+            $contract['originalValue'] = $contract['contractValue'];
+        }
+
+
+        $contract['yearsDuration'] = abs($contract['endYear'] - $contract['startYear']) + 1;
+        $contract['valuePerYear'] = $contract['contractValue'] / $contract['yearsDuration'];
+
+        // Find the consolidated vendor name:
+        if ($vendorData) {
+            $contract['vendorClean'] = $vendorData->consolidateVendorNames($contract['vendorName']);
+        }
+        
+
+
+        // Remove any linebreaks etc.
+        // vendorName
+        // referenceNumber
+        // description
+        // comments
+        foreach (['vendorName', 'referenceNumber', 'description', 'comments', 'extraDescription'] as $textField) {
+            if (isset($contract[$textField]) && $contract[$textField]) {
+                $contract[$textField] = self::removeLinebreaks($contract[$textField]);
+            }
+        }
+    }
 
     public static function getObjectCodeFromDescription($description)
     {
@@ -588,7 +577,6 @@ class Helpers {
         }
 
         return $objectCode;
-
     }
 
     /**
@@ -610,7 +598,6 @@ class Helpers {
         });
 
         return array_unique($items);
-
     }
 
     /**
@@ -629,7 +616,6 @@ class Helpers {
     {
 
         return md5($url) . $extension;
-
     }
 
     /**
@@ -667,5 +653,4 @@ class Helpers {
     {
         return storage_path() . '/' . env('FETCH_METADATA_FOLDER', 'metadata') . '/' . $acronym;
     }
-
 }

--- a/app/VendorData.php
+++ b/app/VendorData.php
@@ -1,691 +1,687 @@
 <?php
 namespace App;
 
-class VendorData {
-
-	public $vendorTable;
-
-	function __construct() {
-
-		$this->vendorTable = self::reindexVendorData(self::$vendors);
-
-	}
-
-	// Re-index the vendor data so that the name variants are keys and the common name is the value for each, to speed up matching in the consolidateVendorNames function:
-	public static function reindexVendorData($vendors) {
-
-		$vendorTable = [];
-
-		foreach($vendors as $vendor => $vendorNames) {
-
-			foreach($vendorNames as $vendorName) {
-
-				$vendorTable[self::cleanupVendorName($vendorName)] = self::cleanupVendorName($vendor);
-
-			}
-
-		}
-
-		return $vendorTable;
-
-	}
-
-	public function consolidateVendorNames($vendorName) {
-
-		$vendorName = self::cleanupVendorName($vendorName);
-
-		$output = $vendorName;
-
-		if(isset($this->vendorTable[$vendorName])) {
-			$output = $this->vendorTable[$vendorName];
-		}
-
-		// if($vendorName != $output) {
-		// 	echo "Replacing [$vendorName] with [$output]. \n";
-		// }
-
-		return $output;
-
-	}
-
-	public static function cleanupVendorName($input) {
-
-		$charactersToRemove = [
-			',',
-			"'",
-			"\t",
-			'.',
-			' INC',
-			' LTD',
-			' -',
-			' /',
-		];
-
-		$output = str_replace($charactersToRemove, '', strtoupper($input));
-		return trim($output);
-
-	}
-
-	public static $vendors = [
-
-		'IBM CANADA' => [
-			'IBM',
-			'IBM Business Consulting Services',
-			'IBM BUSINESS CONSULTING SERVICES/',
-			'IBM CAN*91898807',
-			'IBM CANADA',
-			'IBM CANADA LIMITED',
-			'IBM CANADA LTD',
-			'IBM CANADA LTD.',
-			'IBM CANADA LTEE',
-
-		],
-
-		'BELL CANADA' => [
-			'THE BELL TELEPHONE COMPANY OF',
-			'THE BELL TELEPHONE COMPANY OF CANADA',
-			'The Bell Telephone Company of Canada  / Bell Canada',
-			'Bell',
-			'Bell Advanced Communications',
-			'BELL ALIANT',
-			'BELL ALIANT REGIONAL',
-			'BELL ALIANT REGIONAL COMM.    L.P',
-			'BELL ALIANT REGIONAL COMM.   L.P',
-			'BELL ALIANT REGIONAL COMM. L.P',
-			'BELL ALIANT REGIONAL COMMUNICATIONS',
-			'Bell Aliant Regional Communications L.P',
-			'Bell Aliant Regional Communications L.P.',
-			'Bell Aliant Regional Communications, LP',
-			'BELL CANADA',
-			'Bell Canada ICT Solutions',
-			'Bell Canada, Enterprise Division',
-			'BELL MOBILITY',
-			'Bell Mobility Inc.',
-			'BELL NEXXIA',
-			'BELL WORLD/KANATA WRLSS',
-			'BELL/BCE NEXXIA Inc.',
-
-		],
-
-		'MICROSOFT CANADA' => [
-
-			'Microsoft',
-			'Microsoft Canada',
-			'MICROSOFT CANADA CO.',
-			'MICROSOFT CANADA INC',
-			'MICROSOFT CANADA INC.',
-			'MICROSOFT CANADA LTD.',
-			'MICROSOFT CORPORATION',
-			'MICROSOFT LICENCING , GP',
-			'Microsoft Licensing GP',
-			'MICROSOFT LICENSING, GP',
-
-		],
-
-		'HEWLETT PACKARD' => [
-
-			'Hewlett Packard (Canada)',
-			'HEWLETT PACKARD (CANADA) CO.',
-			'Hewlett Packard (Canada) Ltd',
-			'HEWLETT PACKARD CANADA',
-			'HEWLETT PACKARD CANADA CO.',
-			'Hewlett-Packard (Canada)',
-			'HEWLETT-PACKARD (CANADA) CO',
-			'HEWLETT-PACKARD (CANADA) CO.',
-			'HEWLETT-PACKARD (CANADA) LTD',
-			'Hewlett-Packard (Canada) Ltd.',
-			'HEWLETT-PACKARD CANADA',
-			'Hewlett-Packard Canada Ltd',
-			'HEWLETT-PACKARD CANADA LTD.',
-			'Hewlett-Packard Ltd.',
-			'HewlettPackard (Canada) Co.',
-			'HP Canada Co.',
-
-		],
-
-		'CGI' => [
-
-			'CGI INFORMATION SYSTEMS',
-			'CGI INFORMATION SYSTEMS &',
-			'CGI Information Systems & Management Consultants',
-			'CGI Information Systems & Management Consultants I',
-			'CGI Information Systems & Management Consultants Inc.',
-			'CGI INFORMATION SYSTEMS AND',
-			'CGI Information Systems and Management Consultant',
-			'CGI Information Systems and Management Consultants',
-			'CGI INFORMATION SYSTEMS AND MANAGEMENT CONSULTANTS INC',
-			'CGI INFORMATION SYSTEMS AND MANAGEMENT CONSULTANTS INC.',
-			'CGI INFORMATION SYSTMES AND',
-			'CGI Payroll Services Centre',
-			'CGI/AMS MANAGEMENT SYSTEMS',
-			'CGI INFORMATIONS SYSTEMS AND MANAGEMENTS CONSULTANTS',
-
-		],
-
-		'ROGERS' => [
-
-			'Rogers AT&T',
-			// 'ROGERS BERNADINE',
-			'ROGERS BUSINESS SOLUTIONS',
-			'ROGERS CABLE COMMUNICATIONS INC',
-			'ROGERS CABLE INC',
-			'Rogers Cable Inc.',
-			'Rogers Communications',
-			'ROGERS COMMUNICATIONS CANADA INC.',
-			'ROGERS COMMUNICATIONS INC.',
-			'ROGERS COMMUNICATIONS PARTNERSHIP',
-			'ROGERS DATA CENTRES INC.',
-			'ROGERS OTTAWA',
-			'ROGERS WIRELESS',
-
-		],
-		 
-		 'ORACLE CANADA' => [
-
-		 	'Oracle',
-		 	'ORACLE CANADA',
-		 	'ORACLE CANADA ULC',
-		 	'Oracle Canada ULC.',
-		 	'ORACLE CORPORATION',
-		 	'ORACLE CORPORATION CANADA INC',
-		 	'ORACLE CORPORATION CANADA INC.',
-
-		 ],
-
-		 'CANADIAN CORPS OF COMMISSIONAIRES' => [
-		 	'CAN. COMMISSIONAIRES (OTTAWA)',
-		 	'Canadian Commissionaires (Ottawa)',
-		 	'CANADIAN CORP OF COMMISSIONAIRES',
-		 	'CANADIAN CORPS',
-		 	'CANADIAN CORPS OF COMMISSIONAI',
-		 	'CANADIAN CORPS OF COMMISSIONAIRES',
-		 	'CANADIAN CORPS OF COMMISSIONAIRES (HAMILTON)',
-		 	'Canadian Corps of Commissionaires (NB)',
-		 	'CANADIAN CORPS OF COMMISSIONAIRES OTTAWA DIVISION',
-		 	'Canadian Corps. of Commissionaires  (NS)',
-		 	'CDN CORPS OF COMMISSIONAIRES',
-		 	'CDN. CORPS OF COMMISSIONAIRES',
-		 	'Commissionaire Kingston',
-		 	'COMMISSIONAIRE SERVICES',
-		 	'COMMISSIONAIRES',
-		 	'COMMISSIONAIRES (GREAT LAKES)',
-		 	'COMMISSIONAIRES - NS',
-		 	'COMMISSIONAIRES B C',
-		 	'COMMISSIONAIRES BRITISH COLUMBIA',
-		 	'COMMISSIONAIRES GREAT LAKES',
-		 	'COMMISSIONAIRES MANITOBA DIVISION',
-		 	'Commissionaires Montreal',
-		 	'COMMISSIONAIRES NB-PEI DIVISION',
-		 	'COMMISSIONAIRES NEWFOUNDLAND',
-		 	'COMMISSIONAIRES NOVA SCOTIA',
-		 	'COMMISSIONAIRES OF NFLD',
-		 	'COMMISSIONAIRES OTTAWA',
-		 	'COMMISSIONAIRES OTTAWA (D)',
-		 	'COMMISSIONAIRES OTTAWA (SG)',
-		 	'COMMISSIONAIRES QUEBEC',
-		 	'COMMISSIONAIRES VICTORIA',
-		 	'Commissionaires Victoria &',
-		 	'COMMISSIONAIRES, NB/PEI',
-		 	'COMMISSIONAIRES-N. ALBERTA',
-		 	'COMMISSIONAIRES-OTTAWA',
-		 	'COMMISSIONARIE SERVICES',
-		 	'COMMISSIONNAIRES DU QUEBEC',
-		 	'COMMISSIONNAIRES MONTREAL',
-		 	'CORPS CANADIEN    COMMISSIONNAIRE',
-		 	'CORPS CANADIEN   COMMISSIONNAIRE',
-		 	'Corps Canadien Commissionaire',
-		 	'CORPS CANADIEN COMMISSIONNAIRE',
-		 	'CORPS CANADIEN DES COMMISSIONNAIRE',
-		 	'Corps canadien des commissionnaires',
-		 	'Corps Canadiens des Commissionnaires',
-		 	'CORPS COMMISSIONAIRES',
-		 	'Corps des Commissionnaires du Canada',
-		 	'Corps of Commissionaires',
-		 	'OTTAWA DIVISION - CANADIAN CORPS',
-		 	'OTTAWA DIVISION - CANADIAN CORPS OF COMMISSIONAIRES',
-		 	'The British Columbia Corps of Commissionaires',
-		 	'The Canadian Corps of Commissionaires',
-		 	'THE CANADIAN CORPS OF COMMISSIONAIRES/LE CORPS CANADIEN DES COMMISSIONAIRES',
-		 	'THE COMMISSIONAIRES',
-		 	'@CANADIAN CORPS OF COMMISSIONAIRES',
-		 	'B.C. Corps of Commissionaires',
-		 	'BC CORPS OF COMMISSIONAIRES',
-
-		 ],
-
-		 'TELUS CANADA' => [
-
-		 	'Telus',
-		 	'TELUS COLLABORATION SERVICES',
-		 	'TELUS COMMUNICATION (B.C.) INC.',
-		 	'TELUS COMMUNICATIONS',
-		 	'TELUS COMMUNICATIONS CO.',
-		 	'TELUS COMMUNICATIONS COMPANY',
-		 	'TELUS COMMUNICATIONS INC',
-		 	'TELUS COMMUNICATIONS INC.',
-		 	'TELUS INTEGRATED COMMUNICATIONS',
-		 	'TELUS MOBILITY',
-		 	'TELUS NATIONAL SYSTEMS INC.',
-		 	'Telus Solutions En Sant',
-
-		 ],
-
-		 'VMWARE' => [
-
-		 	'VMWARE',
-		 	'VMware Inc',
-		 	'VMWare Inc.',
-		 	'VMWARE INTERNATIONAL LIMITED',
-		 	'VM Ware Inc.',
-
-		 ],
-
-		 'MACDONALD DETTWILER AND ASSOCIATES' => [
-
-		 	'MACDONALD DETTWILER AND',
-		 	'MDA SYSTEMS',
-		 	'MACDONALD DETT',
-		 	'MACDONALD DETTWILER AND ASS',
-		 	'MDA GEOSPATIAL SERVICES',
-		 	'MACDONALD DETWILLER AND',
-
-		 ],
-
-		 'SASKTEL' => [
-
-		 	'SASKTEL',
-		 	'SASKATCHEWAN TELECOMMUNICATIONS',
-
-		 ],
-
-		 'ELSEVIER BV' => [
-
-		 	'ELSEVIER  B V',
-		 	'ELSEVIER BV',
-
-		 ],
-
-		 'SAS INSTITUTE' => [
-
-		 	'SAS Institute',
-		 	'SAS INSTITUTE ( CANADA ) INC',
-		 	'SAS INSTITUTE (CANADA) INC',
-		 	'SAS INSTITUTE (CANADA) INC.',
-		 	'SAS Institute Canada',
-		 	'SAS INSTITUTE CANADA INC',
-		 	'SAS INSTITUTE CANADA INC.',
-		 	'SAS Institute Inc.',
-		 	'SAS Instuitute',
-
-		 ],
-
-		 'SCHNEIDER ELECTRIC CANADA' => [
-
-		 	'SCHNEIDER ELECTRIC CANADA',
-		 	'SCHNEIDER ELECTRIC CANADA INC',
-		 	'SCHNEIDER ELECTRIC CANADA INC.',
-		 	'SCHNEIDER ELECTRIC IT CORPORATION',
-		 ],
-
-		 'SECURITAS' => [
-
-		 	'SECURITAS CANADA LTD',
-		 	'Securitas Canada Ltd.',
-		 	'SECURITAS FRANCE SARL',
-
-		 ],
-
-		 'SHARP ELECTRONICS' => [
-
-		 	'Sharp Electronics',
-		 	'SHARP ELECTRONICS OF CA',
-		 	'SHARP ELECTRONICS OF CANADA',
-		 	'SHARP ELECTRONICS OF CANADA LT',
-		 	'SHARP ELECTRONICS OF CANADA LTD',
-		 	'Sharp Electronics of Canada Ltd.',
-		 	'SHARP ELECTRONICS OF CDA LTD',
-
-		 ],
-
-		 'SHRED IT' => [
-
-		 	'SHRED IT',
-		 	'SHRED IT INTERNATIONAL ULC',
-		 	'SHRED-IT',
-		 	'SHRED-IT - INTERNATIONAL INC',
-		 	'Shred-It Canada (Toronto)',
-		 	'SHRED-IT HALIFAX',
-		 	'SHRED-IT INTERNATIONAL',
-		 	'SHRED-IT INTERNATIONAL INC.',
-		 	'Shred-it International ULC',
-		 	'SHRED-IT MONTR��AL',
-		 	'SHRED-IT SOUTHWESTERN ONTARIO',
-
-		 ],
-
-		 'SIEMENS' => [
-
-		 	'SIEMENS',
-		 	'SIEMENS - TECHNOLOGIES',
-		 	'SIEMENS BUILDING TECHNOLOGIES LTD',
-		 	'SIEMENS BUILDING TECHNOLOGIES LTD.',
-		 	'SIEMENS CA LIMITED / LIMITEE',
-		 	'SIEMENS CANADA LIMITED',
-		 	'SIEMENS CANADA LIMITED / LIMITEE',
-		 	'SIEMENS CANADA LTD',
-		 	'SIEMENS CANADA LTD.',
-		 	'SIEMENS DEMAG DELEVAL',
-		 	'SIEMENS INDUSTRY SOFTWARE LTD.',
-		 	'SIEMENS PLM',
-		 	'SIEMENS PRODUCT LIFECYCLE',
-		 	'SIEMENS WATER TECHNOLOGIES CANADA',
-
-		 ],
-
-		 'HITACHI DATA SYSTEMS' => [
-		 	'HITACHI DATA SYSTEMS',
-		 	'HITACHI DATA SYSTEMS INC.',
-		 	'HITACHI HIGH TECHNOLOGIES CANADA INC.',
-		 	'HITACHI HIGH-TECHNOLOGIES CANADA',
-		 ],
-
-		 'SYMANTEC' => [
-		 	'SYMANTEC',
-		 	'SYMANTEC CORPORATION',
-		 ],
-
-		 'COGNOS' => [
-		 	'Cognos Inc.',
-		 	'COGNOS INCORPORATED',
-		 ],
-
-		 'ADGA GROUP' => [
-		 	'ADGA GROUP CONSULTANTS INC',
-		 	'ADGA GROUP CONSULTANTS INC.',
-		 	'ADGA GROUP THE',
-		 ],
-
-		 'PRICEWATERHOUSE COOPERS' => [
-		 	'Pricewaterhouse Coopers',
-		 	'PRICEWATERHOUSE COOPERS INC',
-		 	'PRICEWATERHOUSE COOPERS LLP',
-		 	'Pricewaterhouse Coopers Llp.',
-		 	'PRICEWATERHOUSECOOPERS',
-		 	'PRICEWATERHOUSECOOPERS (PWC) LLP',
-		 	'PRICEWATERHOUSECOOPERS LLP',
-		 	'PRICE WATER HOUSE',
-		 	'PRICE WATERHOUSE COOPERS LLP',
-		 	'PwC Consulting, A Business',
-		 	'PWC Management Services LP',
-		 ],
-
-		 'BELL TEXTRON HELICOPTER' => [
-		 	'BELL HELICOPTER',
-		 	'BELL HELICOPTER TEXTRON CANADA LTD',
-		 	'BELL HELICOPTER TEXTRON INC.',
-		 ],
-
-		 'MCKESSON CANADA' => [
-		 	'McKesson  Canada',
-		 	'MCKESSON AUTOMATION CANADA',
-		 	'MCKESSON CA',
-		 	'MCKESSON CA CORPORATION',
-		 	'MCKESSON CANADA',
-		 	'MCKESSON CANADA CORPORATION',
-		 ],
-
-		 'RANDSTAD' => [
-		 	'RANDSTAD',
-		 	'RANDSTAD CANADA',
-		 	'RANDSTAD INTERIM INC',
-		 	'RANDSTAD INTERIM INC.',
-		 	'RANDSTAD PARC JARRY',
-		 ],
-
-		 'COMPUTER ASSOCIATES CANADA' => [
-		 	'COMPUTER ASSOCIATES CANADA COM',
-		 	'COMPUTER ASSOCIATES CANADA COMPANY',
-		 	'Computer Associates Canada Ltd.',
-		 ],
-
-		 'COMPUCOM CANADA' => [
-		 	'COMPUCOM',
-		 	'COMPUCOM CANADA',
-		 	'COMPUCOM CANADA CO',
-		 	'COMPUCOM CANADA CO.',
-		 ],
-
-		 'TERAMACH TECHNOLOGIES' => [
-		 	'TERAMACH',
-		 	'TERAMACH TECHNOLOGICS INC',
-		 	'TERAMACH TECHNOLOGIES INC',
-		 	'TERAMACH TECHNOLOGIES INC.',
-		 	'Teramach Techonologies',
-		 ],
-
-		 'MODIS CANADA' => [
-		 	'MODIS  CANADA INC.',
-		 	'MODIS CANADA INC',
-		 	'MODIS CANADA INC.',
-		 ],
-
-		 'MAPLESOFT CONSULTING' => [
-		 	'MAPLESOFT',
-		 	'Maplesoft Administrative Services',
-		 	'MAPLESOFT ADMINISTRATIVE SERVICES INC',
-		 	'MAPLESOFT CONSULTING',
-		 	'MAPLESOFT CONSULTING INC.',
-		 	'MAPLESOFT LEGAL SUPPORT SERVICES',
-		 	'Maplesoft Technology Inc.',
-		 ],
-
-		 'MobilShred (Recall)' => [
-		 	'MobilShred (Recall)',
-		 	'MobilShred Inc (Recall)',
-		 	'MobilShred Inc.',
-		 	'Mobilshred Inc. (Operating as Recal',
-		 	'Mobilshred Inc. (Operating as Recall)',
-		 	'MobilShred Inc. (Recall)',
-		 ],
-
-		 'G4S SECURITY SERVICES' => [
-		 	'G4S CASH SOLUTIONS (CANADA)',
-		 	'G4S SECURITY SERVICES (CANADA)',
-		 	'G4S SECURITY SERVICES (CANADA) LTD.',
-		 ],
-
-		 'CAE' => [
-		 	'CAE FLIGHTSCAPE INC',
-		 	'CAE INC',
-		 	'CAE Simuflite Inc.',
-		 ],
-
-		 'ITEX' => [
-		 	'ITEX',
-		 	'ITEX ENTERPRISE SOLUTIONS',
-		 	'ITEX Entreprise Solutions',
-		 	'ITEX INC',
-		 	'ITEX INC.',
-		 ],
-
-		 'MARCOMM' => [
-		 	'MARCOMM',
-		 	'Marcomm Fibre Optics',
-		 	'MARCOMM FIBRE OPTICS INC.',
-		 	'MARCOMM INC',
-		 	'MARCOMM INC.',
-		 	'MARCOMM SYSTEMS GROUP INC',
-		 ],
-
-		 'CONEXSYS' => [
-		 	'CONEXSYS COMMUNICATION LTD.',
-		 	'Conexsys Communications',
-		 	'CONEXSYS COMMUNICATIONS LIMITED',
-		 	'CONEXSYS COMMUNICATIONS LTD',
-		 	'CONEXSYS COMMUNICATIONS LTD.',
-		 ],
-
-		 'PROVINCIAL AIRLINES' => [
-		 	'PROVINCIAL AEROSPACE LTD (PAL)',
-		 	'PROVINCIAL AIRLINES LTD',
-		 ],
-
-		 'ADVANCED CHIPPEWA TECHNOLOGIES' => [
-		 	'ADVANCED CHIPPEWA TECHNOLOGI',
-		 	'ADVANCED CHIPPEWA TECHNOLOGIES',
-		 	'ADVANCED CHIPPEWA TECHNOLOGIES INC',
-		 	'ADVANCED CHIPPEWA TECHNOLOGIES INC.',
-		 ],
-
-		 'DNR CONSULTING GROUP' => [
-		 	'DNR CONSULTING GROUP',
-		 	'DNR CONSULTING GROUP INC.',
-		 	'DNR GROUP',
-		 	'DNR GROUP INC.',
-		 ],
-
-		 'NOVELL CANADA' => [
-		 	'Novell',
-		 	'NOVELL CANADA LTD',
-		 	'NOVELL CANADA LTD.',
-		 	'NOVELL CANADA,LTD.',
-		 ],
-
-		 'MCAFEE INTERNATIONAL' => [
-		 	'MCAFEE INTERNATIONAL B.V.',
-		 	'MCAFEE IRELAND LIMITED',
-		 ],
-
-		 'DELOITTE AND TOUCHE' => [
-		 	'Deloitte',
-		 	'DELOITTE & TOUCHE',
-		 	'DELOITTE & TOUCHE LLP',
-		 	'DELOITTE & TOUCHE, LLP',
-		 	'Deloitte and Touche',
-		 	'DELOITTE AND TOUCHE LLP',
-		 	'DELOITTE AND TOUCHE, LLP',
-		 	'DELOITTE CONSULTING INC.',
-		 	'DELOITTE INC',
-		 	'Deloitte Inc.',
-		 	'Deloitte LLP',
-		 ],
-
-		 'ATCO FRONTEC' => [
-		 	'ATCO FRONTEC CORP.',
-		 	'ATCO STRUCTURES & LOGISTICS LTD.',
-		 	'ATCO STRUCTURES AND LOGISTICS',
-		 ],
-
-		 'IBISKA TELECOM' => [
-		 	'IBISKA',
-		 	'IBISKA TELECOM INC.',
-		 ],
-
-		 'OEI KRUEGER' => [
-		 	'OEI',
-		 	'OEI KRUEGER INTERNATIONAL INC',
-		 ],
-
-		 'EXCEL HUMAN RESOURCES' => [
-		 	'EXCEL HR',
-		 	'Excel Human Resources',
-		 	'EXCEL HUMAN RESOURCES INC',
-		 	'EXCEL HUMAN RESOURCES INC.',
-		 	'Excel Human Ressources Inc',
-		 	'Excel Human Ressources Inc.',
-		 ],
-
-		 'MINDWIRE SYSTEMS' => [
-		 	'MINDWIRE',
-		 	'Mindwire (Zylog)',
-		 	'MINDWIRE SYSTEMS LTD',
-		 	'MINDWIRE SYSTEMS LTD.',
-		 ],
-
-		 'EBSCO CANADA' => [
-		 	'EBSCO Canada',
-		 	'EBSCO Canada Ltd',
-		 	'EBSCO CANADA LTD.',
-		 	'EBSCO CANADA LTEE',
-		 	'Ebsco Canada Lt̩e',
-		 	'EBSCO CANADA LT��E',
-		 	'EBSCO PUBLISHING',
-		 ],
-
-		 'CISTEL TECHNOLOGY' => [
-		 	'Cistel',
-		 	'CISTEL TECHNOLOGY',
-		 	'Cistel Technology Inc',
-		 	'CISTEL TECHNOLOGY INC TECSIS CORPORATION IN JOINT VENTURE',
-		 	'CISTEL TECHNOLOGY INC.',
-		 ],
-
-		 'CITRIX' => [
-		 	'Citrix',
-		 	'CITRIX ONLINE LLC',
-		 	'CITRIX SYSTEMS INC',
-		 	'CITRIX SYSTEMS INC.',
-		 	'CITRIX SYSTEMS, INC.',
-		 ],
-
-		 'NISHA TECHNOLOGIES' => [
-		 	'Nisha',
-		 	'NISHA    Technologie',
-		 	'NISHA TECHNOLOGIE INC.',
-		 	'Nisha Technologies',
-		 	'NISHA TECHNOLOGIES INC',
-		 	'NISHA TECHNOLOGIES INC.',
-		 ],
-
-		 'ECLIPSYS SOLUTIONS' => [
-		 	'ECLIPSYS',
-		 	'ECLIPSYS SOLUTIONS INC',
-		 	'ECLIPSYS SOLUTIONS INC.',
-		 ],
-
-		 'TRANSPOLAR TECHNOLOGY' => [
-		 	'TRANSPOLAR TECHNOLOGY CORP',
-		 	'TRANSPOLAR TECHNOLOGY CORP.',
-		 	'TRANSPOLAR TECHNOLOGY CORPORATION',
-		 ],
-
-		 'MOTOROLA SOLUTIONS CANADA' => [
-		 	'MOTOROLA CANADA LTD',
-		 	'MOTOROLA NATIONAL PARTS',
-		 	'MOTOROLA SOLUTIONS CANADA INC',
-		 	'MOTOROLA SOLUTIONS CANADA INC.',
-		 ],
-
-		 'RESOLVE MARINE GROUP' => [
-		 	'RESOLVE',
-		 	'RESOLVE MARINE GROUP INC',
-		 ],
-
-		 'SALVATION ARMY' => [
-		 	'SALVATION ARMY',
-		 	'SALVATION ARMY ARC',
-		 	'SALVATION ARMY BELKIN HOUSE',
-		 	'SALVATION ARMY BOOTH CENTRE BRANTFORD',
-		 	'SALVATION ARMY CENTRE OF HOPE',
-		 	'SALVATION ARMY CORRECTIONAL &',
-		 	'SALVATION ARMY CORRECTIONAL AND JUSTICE SERVICES GREENFIELD HOUSE THE',
-		 	'SALVATION ARMY HARBOUR LIGHT',
-		 	'SALVATION ARMY HARBOUR LIGHTS CORP',
-		 	'SALVATION ARMY WAGNER COTTAGE',
-		 ],
-
-		 'VERITAS TECHNOLOGIES' => [
-		 	'Veritas',
-		 	'VERITAS TECHNOLOGIES LLC',
-		 ],
-
-		 'SIERRA SYSTEMS GROUP' => [
-		 	'SIERRA SYSTEMS',
-		 	'SIERRA SYSTEMS GROUP INC',
-		 	'SIERRA SYSTEMS GROUP INC.',
-		 ],
-
-
-	];
-
+class VendorData
+{
+
+    public $vendorTable;
+
+    function __construct()
+    {
+
+        $this->vendorTable = self::reindexVendorData(self::$vendors);
+    }
+
+    // Re-index the vendor data so that the name variants are keys and the common name is the value for each, to speed up matching in the consolidateVendorNames function:
+    public static function reindexVendorData($vendors)
+    {
+
+        $vendorTable = [];
+
+        foreach ($vendors as $vendor => $vendorNames) {
+            foreach ($vendorNames as $vendorName) {
+                $vendorTable[self::cleanupVendorName($vendorName)] = self::cleanupVendorName($vendor);
+            }
+        }
+
+        return $vendorTable;
+    }
+
+    public function consolidateVendorNames($vendorName)
+    {
+
+        $vendorName = self::cleanupVendorName($vendorName);
+
+        $output = $vendorName;
+
+        if (isset($this->vendorTable[$vendorName])) {
+            $output = $this->vendorTable[$vendorName];
+        }
+
+        // if($vendorName != $output) {
+        // 	echo "Replacing [$vendorName] with [$output]. \n";
+        // }
+
+        return $output;
+    }
+
+    public static function cleanupVendorName($input)
+    {
+
+        $charactersToRemove = [
+            ',',
+            "'",
+            "\t",
+            '.',
+            ' INC',
+            ' LTD',
+            ' -',
+            ' /',
+        ];
+
+        $output = str_replace($charactersToRemove, '', strtoupper($input));
+        return trim($output);
+    }
+
+    public static $vendors = [
+
+        'IBM CANADA' => [
+            'IBM',
+            'IBM Business Consulting Services',
+            'IBM BUSINESS CONSULTING SERVICES/',
+            'IBM CAN*91898807',
+            'IBM CANADA',
+            'IBM CANADA LIMITED',
+            'IBM CANADA LTD',
+            'IBM CANADA LTD.',
+            'IBM CANADA LTEE',
+
+        ],
+
+        'BELL CANADA' => [
+            'THE BELL TELEPHONE COMPANY OF',
+            'THE BELL TELEPHONE COMPANY OF CANADA',
+            'The Bell Telephone Company of Canada  / Bell Canada',
+            'Bell',
+            'Bell Advanced Communications',
+            'BELL ALIANT',
+            'BELL ALIANT REGIONAL',
+            'BELL ALIANT REGIONAL COMM.    L.P',
+            'BELL ALIANT REGIONAL COMM.   L.P',
+            'BELL ALIANT REGIONAL COMM. L.P',
+            'BELL ALIANT REGIONAL COMMUNICATIONS',
+            'Bell Aliant Regional Communications L.P',
+            'Bell Aliant Regional Communications L.P.',
+            'Bell Aliant Regional Communications, LP',
+            'BELL CANADA',
+            'Bell Canada ICT Solutions',
+            'Bell Canada, Enterprise Division',
+            'BELL MOBILITY',
+            'Bell Mobility Inc.',
+            'BELL NEXXIA',
+            'BELL WORLD/KANATA WRLSS',
+            'BELL/BCE NEXXIA Inc.',
+
+        ],
+
+        'MICROSOFT CANADA' => [
+
+            'Microsoft',
+            'Microsoft Canada',
+            'MICROSOFT CANADA CO.',
+            'MICROSOFT CANADA INC',
+            'MICROSOFT CANADA INC.',
+            'MICROSOFT CANADA LTD.',
+            'MICROSOFT CORPORATION',
+            'MICROSOFT LICENCING , GP',
+            'Microsoft Licensing GP',
+            'MICROSOFT LICENSING, GP',
+
+        ],
+
+        'HEWLETT PACKARD' => [
+
+            'Hewlett Packard (Canada)',
+            'HEWLETT PACKARD (CANADA) CO.',
+            'Hewlett Packard (Canada) Ltd',
+            'HEWLETT PACKARD CANADA',
+            'HEWLETT PACKARD CANADA CO.',
+            'Hewlett-Packard (Canada)',
+            'HEWLETT-PACKARD (CANADA) CO',
+            'HEWLETT-PACKARD (CANADA) CO.',
+            'HEWLETT-PACKARD (CANADA) LTD',
+            'Hewlett-Packard (Canada) Ltd.',
+            'HEWLETT-PACKARD CANADA',
+            'Hewlett-Packard Canada Ltd',
+            'HEWLETT-PACKARD CANADA LTD.',
+            'Hewlett-Packard Ltd.',
+            'HewlettPackard (Canada) Co.',
+            'HP Canada Co.',
+
+        ],
+
+        'CGI' => [
+
+            'CGI INFORMATION SYSTEMS',
+            'CGI INFORMATION SYSTEMS &',
+            'CGI Information Systems & Management Consultants',
+            'CGI Information Systems & Management Consultants I',
+            'CGI Information Systems & Management Consultants Inc.',
+            'CGI INFORMATION SYSTEMS AND',
+            'CGI Information Systems and Management Consultant',
+            'CGI Information Systems and Management Consultants',
+            'CGI INFORMATION SYSTEMS AND MANAGEMENT CONSULTANTS INC',
+            'CGI INFORMATION SYSTEMS AND MANAGEMENT CONSULTANTS INC.',
+            'CGI INFORMATION SYSTMES AND',
+            'CGI Payroll Services Centre',
+            'CGI/AMS MANAGEMENT SYSTEMS',
+            'CGI INFORMATIONS SYSTEMS AND MANAGEMENTS CONSULTANTS',
+
+        ],
+
+        'ROGERS' => [
+
+            'Rogers AT&T',
+            // 'ROGERS BERNADINE',
+            'ROGERS BUSINESS SOLUTIONS',
+            'ROGERS CABLE COMMUNICATIONS INC',
+            'ROGERS CABLE INC',
+            'Rogers Cable Inc.',
+            'Rogers Communications',
+            'ROGERS COMMUNICATIONS CANADA INC.',
+            'ROGERS COMMUNICATIONS INC.',
+            'ROGERS COMMUNICATIONS PARTNERSHIP',
+            'ROGERS DATA CENTRES INC.',
+            'ROGERS OTTAWA',
+            'ROGERS WIRELESS',
+
+        ],
+         
+         'ORACLE CANADA' => [
+
+            'Oracle',
+            'ORACLE CANADA',
+            'ORACLE CANADA ULC',
+            'Oracle Canada ULC.',
+            'ORACLE CORPORATION',
+            'ORACLE CORPORATION CANADA INC',
+            'ORACLE CORPORATION CANADA INC.',
+
+         ],
+
+         'CANADIAN CORPS OF COMMISSIONAIRES' => [
+            'CAN. COMMISSIONAIRES (OTTAWA)',
+            'Canadian Commissionaires (Ottawa)',
+            'CANADIAN CORP OF COMMISSIONAIRES',
+            'CANADIAN CORPS',
+            'CANADIAN CORPS OF COMMISSIONAI',
+            'CANADIAN CORPS OF COMMISSIONAIRES',
+            'CANADIAN CORPS OF COMMISSIONAIRES (HAMILTON)',
+            'Canadian Corps of Commissionaires (NB)',
+            'CANADIAN CORPS OF COMMISSIONAIRES OTTAWA DIVISION',
+            'Canadian Corps. of Commissionaires  (NS)',
+            'CDN CORPS OF COMMISSIONAIRES',
+            'CDN. CORPS OF COMMISSIONAIRES',
+            'Commissionaire Kingston',
+            'COMMISSIONAIRE SERVICES',
+            'COMMISSIONAIRES',
+            'COMMISSIONAIRES (GREAT LAKES)',
+            'COMMISSIONAIRES - NS',
+            'COMMISSIONAIRES B C',
+            'COMMISSIONAIRES BRITISH COLUMBIA',
+            'COMMISSIONAIRES GREAT LAKES',
+            'COMMISSIONAIRES MANITOBA DIVISION',
+            'Commissionaires Montreal',
+            'COMMISSIONAIRES NB-PEI DIVISION',
+            'COMMISSIONAIRES NEWFOUNDLAND',
+            'COMMISSIONAIRES NOVA SCOTIA',
+            'COMMISSIONAIRES OF NFLD',
+            'COMMISSIONAIRES OTTAWA',
+            'COMMISSIONAIRES OTTAWA (D)',
+            'COMMISSIONAIRES OTTAWA (SG)',
+            'COMMISSIONAIRES QUEBEC',
+            'COMMISSIONAIRES VICTORIA',
+            'Commissionaires Victoria &',
+            'COMMISSIONAIRES, NB/PEI',
+            'COMMISSIONAIRES-N. ALBERTA',
+            'COMMISSIONAIRES-OTTAWA',
+            'COMMISSIONARIE SERVICES',
+            'COMMISSIONNAIRES DU QUEBEC',
+            'COMMISSIONNAIRES MONTREAL',
+            'CORPS CANADIEN    COMMISSIONNAIRE',
+            'CORPS CANADIEN   COMMISSIONNAIRE',
+            'Corps Canadien Commissionaire',
+            'CORPS CANADIEN COMMISSIONNAIRE',
+            'CORPS CANADIEN DES COMMISSIONNAIRE',
+            'Corps canadien des commissionnaires',
+            'Corps Canadiens des Commissionnaires',
+            'CORPS COMMISSIONAIRES',
+            'Corps des Commissionnaires du Canada',
+            'Corps of Commissionaires',
+            'OTTAWA DIVISION - CANADIAN CORPS',
+            'OTTAWA DIVISION - CANADIAN CORPS OF COMMISSIONAIRES',
+            'The British Columbia Corps of Commissionaires',
+            'The Canadian Corps of Commissionaires',
+            'THE CANADIAN CORPS OF COMMISSIONAIRES/LE CORPS CANADIEN DES COMMISSIONAIRES',
+            'THE COMMISSIONAIRES',
+            '@CANADIAN CORPS OF COMMISSIONAIRES',
+            'B.C. Corps of Commissionaires',
+            'BC CORPS OF COMMISSIONAIRES',
+
+         ],
+
+         'TELUS CANADA' => [
+
+            'Telus',
+            'TELUS COLLABORATION SERVICES',
+            'TELUS COMMUNICATION (B.C.) INC.',
+            'TELUS COMMUNICATIONS',
+            'TELUS COMMUNICATIONS CO.',
+            'TELUS COMMUNICATIONS COMPANY',
+            'TELUS COMMUNICATIONS INC',
+            'TELUS COMMUNICATIONS INC.',
+            'TELUS INTEGRATED COMMUNICATIONS',
+            'TELUS MOBILITY',
+            'TELUS NATIONAL SYSTEMS INC.',
+            'Telus Solutions En Sant',
+
+         ],
+
+         'VMWARE' => [
+
+            'VMWARE',
+            'VMware Inc',
+            'VMWare Inc.',
+            'VMWARE INTERNATIONAL LIMITED',
+            'VM Ware Inc.',
+
+         ],
+
+         'MACDONALD DETTWILER AND ASSOCIATES' => [
+
+            'MACDONALD DETTWILER AND',
+            'MDA SYSTEMS',
+            'MACDONALD DETT',
+            'MACDONALD DETTWILER AND ASS',
+            'MDA GEOSPATIAL SERVICES',
+            'MACDONALD DETWILLER AND',
+
+         ],
+
+         'SASKTEL' => [
+
+            'SASKTEL',
+            'SASKATCHEWAN TELECOMMUNICATIONS',
+
+         ],
+
+         'ELSEVIER BV' => [
+
+            'ELSEVIER  B V',
+            'ELSEVIER BV',
+
+         ],
+
+         'SAS INSTITUTE' => [
+
+            'SAS Institute',
+            'SAS INSTITUTE ( CANADA ) INC',
+            'SAS INSTITUTE (CANADA) INC',
+            'SAS INSTITUTE (CANADA) INC.',
+            'SAS Institute Canada',
+            'SAS INSTITUTE CANADA INC',
+            'SAS INSTITUTE CANADA INC.',
+            'SAS Institute Inc.',
+            'SAS Instuitute',
+
+         ],
+
+         'SCHNEIDER ELECTRIC CANADA' => [
+
+            'SCHNEIDER ELECTRIC CANADA',
+            'SCHNEIDER ELECTRIC CANADA INC',
+            'SCHNEIDER ELECTRIC CANADA INC.',
+            'SCHNEIDER ELECTRIC IT CORPORATION',
+         ],
+
+         'SECURITAS' => [
+
+            'SECURITAS CANADA LTD',
+            'Securitas Canada Ltd.',
+            'SECURITAS FRANCE SARL',
+
+         ],
+
+         'SHARP ELECTRONICS' => [
+
+            'Sharp Electronics',
+            'SHARP ELECTRONICS OF CA',
+            'SHARP ELECTRONICS OF CANADA',
+            'SHARP ELECTRONICS OF CANADA LT',
+            'SHARP ELECTRONICS OF CANADA LTD',
+            'Sharp Electronics of Canada Ltd.',
+            'SHARP ELECTRONICS OF CDA LTD',
+
+         ],
+
+         'SHRED IT' => [
+
+            'SHRED IT',
+            'SHRED IT INTERNATIONAL ULC',
+            'SHRED-IT',
+            'SHRED-IT - INTERNATIONAL INC',
+            'Shred-It Canada (Toronto)',
+            'SHRED-IT HALIFAX',
+            'SHRED-IT INTERNATIONAL',
+            'SHRED-IT INTERNATIONAL INC.',
+            'Shred-it International ULC',
+            'SHRED-IT MONTR��AL',
+            'SHRED-IT SOUTHWESTERN ONTARIO',
+
+         ],
+
+         'SIEMENS' => [
+
+            'SIEMENS',
+            'SIEMENS - TECHNOLOGIES',
+            'SIEMENS BUILDING TECHNOLOGIES LTD',
+            'SIEMENS BUILDING TECHNOLOGIES LTD.',
+            'SIEMENS CA LIMITED / LIMITEE',
+            'SIEMENS CANADA LIMITED',
+            'SIEMENS CANADA LIMITED / LIMITEE',
+            'SIEMENS CANADA LTD',
+            'SIEMENS CANADA LTD.',
+            'SIEMENS DEMAG DELEVAL',
+            'SIEMENS INDUSTRY SOFTWARE LTD.',
+            'SIEMENS PLM',
+            'SIEMENS PRODUCT LIFECYCLE',
+            'SIEMENS WATER TECHNOLOGIES CANADA',
+
+         ],
+
+         'HITACHI DATA SYSTEMS' => [
+            'HITACHI DATA SYSTEMS',
+            'HITACHI DATA SYSTEMS INC.',
+            'HITACHI HIGH TECHNOLOGIES CANADA INC.',
+            'HITACHI HIGH-TECHNOLOGIES CANADA',
+         ],
+
+         'SYMANTEC' => [
+            'SYMANTEC',
+            'SYMANTEC CORPORATION',
+         ],
+
+         'COGNOS' => [
+            'Cognos Inc.',
+            'COGNOS INCORPORATED',
+         ],
+
+         'ADGA GROUP' => [
+            'ADGA GROUP CONSULTANTS INC',
+            'ADGA GROUP CONSULTANTS INC.',
+            'ADGA GROUP THE',
+         ],
+
+         'PRICEWATERHOUSE COOPERS' => [
+            'Pricewaterhouse Coopers',
+            'PRICEWATERHOUSE COOPERS INC',
+            'PRICEWATERHOUSE COOPERS LLP',
+            'Pricewaterhouse Coopers Llp.',
+            'PRICEWATERHOUSECOOPERS',
+            'PRICEWATERHOUSECOOPERS (PWC) LLP',
+            'PRICEWATERHOUSECOOPERS LLP',
+            'PRICE WATER HOUSE',
+            'PRICE WATERHOUSE COOPERS LLP',
+            'PwC Consulting, A Business',
+            'PWC Management Services LP',
+         ],
+
+         'BELL TEXTRON HELICOPTER' => [
+            'BELL HELICOPTER',
+            'BELL HELICOPTER TEXTRON CANADA LTD',
+            'BELL HELICOPTER TEXTRON INC.',
+         ],
+
+         'MCKESSON CANADA' => [
+            'McKesson  Canada',
+            'MCKESSON AUTOMATION CANADA',
+            'MCKESSON CA',
+            'MCKESSON CA CORPORATION',
+            'MCKESSON CANADA',
+            'MCKESSON CANADA CORPORATION',
+         ],
+
+         'RANDSTAD' => [
+            'RANDSTAD',
+            'RANDSTAD CANADA',
+            'RANDSTAD INTERIM INC',
+            'RANDSTAD INTERIM INC.',
+            'RANDSTAD PARC JARRY',
+         ],
+
+         'COMPUTER ASSOCIATES CANADA' => [
+            'COMPUTER ASSOCIATES CANADA COM',
+            'COMPUTER ASSOCIATES CANADA COMPANY',
+            'Computer Associates Canada Ltd.',
+         ],
+
+         'COMPUCOM CANADA' => [
+            'COMPUCOM',
+            'COMPUCOM CANADA',
+            'COMPUCOM CANADA CO',
+            'COMPUCOM CANADA CO.',
+         ],
+
+         'TERAMACH TECHNOLOGIES' => [
+            'TERAMACH',
+            'TERAMACH TECHNOLOGICS INC',
+            'TERAMACH TECHNOLOGIES INC',
+            'TERAMACH TECHNOLOGIES INC.',
+            'Teramach Techonologies',
+         ],
+
+         'MODIS CANADA' => [
+            'MODIS  CANADA INC.',
+            'MODIS CANADA INC',
+            'MODIS CANADA INC.',
+         ],
+
+         'MAPLESOFT CONSULTING' => [
+            'MAPLESOFT',
+            'Maplesoft Administrative Services',
+            'MAPLESOFT ADMINISTRATIVE SERVICES INC',
+            'MAPLESOFT CONSULTING',
+            'MAPLESOFT CONSULTING INC.',
+            'MAPLESOFT LEGAL SUPPORT SERVICES',
+            'Maplesoft Technology Inc.',
+         ],
+
+         'MobilShred (Recall)' => [
+            'MobilShred (Recall)',
+            'MobilShred Inc (Recall)',
+            'MobilShred Inc.',
+            'Mobilshred Inc. (Operating as Recal',
+            'Mobilshred Inc. (Operating as Recall)',
+            'MobilShred Inc. (Recall)',
+         ],
+
+         'G4S SECURITY SERVICES' => [
+            'G4S CASH SOLUTIONS (CANADA)',
+            'G4S SECURITY SERVICES (CANADA)',
+            'G4S SECURITY SERVICES (CANADA) LTD.',
+         ],
+
+         'CAE' => [
+            'CAE FLIGHTSCAPE INC',
+            'CAE INC',
+            'CAE Simuflite Inc.',
+         ],
+
+         'ITEX' => [
+            'ITEX',
+            'ITEX ENTERPRISE SOLUTIONS',
+            'ITEX Entreprise Solutions',
+            'ITEX INC',
+            'ITEX INC.',
+         ],
+
+         'MARCOMM' => [
+            'MARCOMM',
+            'Marcomm Fibre Optics',
+            'MARCOMM FIBRE OPTICS INC.',
+            'MARCOMM INC',
+            'MARCOMM INC.',
+            'MARCOMM SYSTEMS GROUP INC',
+         ],
+
+         'CONEXSYS' => [
+            'CONEXSYS COMMUNICATION LTD.',
+            'Conexsys Communications',
+            'CONEXSYS COMMUNICATIONS LIMITED',
+            'CONEXSYS COMMUNICATIONS LTD',
+            'CONEXSYS COMMUNICATIONS LTD.',
+         ],
+
+         'PROVINCIAL AIRLINES' => [
+            'PROVINCIAL AEROSPACE LTD (PAL)',
+            'PROVINCIAL AIRLINES LTD',
+         ],
+
+         'ADVANCED CHIPPEWA TECHNOLOGIES' => [
+            'ADVANCED CHIPPEWA TECHNOLOGI',
+            'ADVANCED CHIPPEWA TECHNOLOGIES',
+            'ADVANCED CHIPPEWA TECHNOLOGIES INC',
+            'ADVANCED CHIPPEWA TECHNOLOGIES INC.',
+         ],
+
+         'DNR CONSULTING GROUP' => [
+            'DNR CONSULTING GROUP',
+            'DNR CONSULTING GROUP INC.',
+            'DNR GROUP',
+            'DNR GROUP INC.',
+         ],
+
+         'NOVELL CANADA' => [
+            'Novell',
+            'NOVELL CANADA LTD',
+            'NOVELL CANADA LTD.',
+            'NOVELL CANADA,LTD.',
+         ],
+
+         'MCAFEE INTERNATIONAL' => [
+            'MCAFEE INTERNATIONAL B.V.',
+            'MCAFEE IRELAND LIMITED',
+         ],
+
+         'DELOITTE AND TOUCHE' => [
+            'Deloitte',
+            'DELOITTE & TOUCHE',
+            'DELOITTE & TOUCHE LLP',
+            'DELOITTE & TOUCHE, LLP',
+            'Deloitte and Touche',
+            'DELOITTE AND TOUCHE LLP',
+            'DELOITTE AND TOUCHE, LLP',
+            'DELOITTE CONSULTING INC.',
+            'DELOITTE INC',
+            'Deloitte Inc.',
+            'Deloitte LLP',
+         ],
+
+         'ATCO FRONTEC' => [
+            'ATCO FRONTEC CORP.',
+            'ATCO STRUCTURES & LOGISTICS LTD.',
+            'ATCO STRUCTURES AND LOGISTICS',
+         ],
+
+         'IBISKA TELECOM' => [
+            'IBISKA',
+            'IBISKA TELECOM INC.',
+         ],
+
+         'OEI KRUEGER' => [
+            'OEI',
+            'OEI KRUEGER INTERNATIONAL INC',
+         ],
+
+         'EXCEL HUMAN RESOURCES' => [
+            'EXCEL HR',
+            'Excel Human Resources',
+            'EXCEL HUMAN RESOURCES INC',
+            'EXCEL HUMAN RESOURCES INC.',
+            'Excel Human Ressources Inc',
+            'Excel Human Ressources Inc.',
+         ],
+
+         'MINDWIRE SYSTEMS' => [
+            'MINDWIRE',
+            'Mindwire (Zylog)',
+            'MINDWIRE SYSTEMS LTD',
+            'MINDWIRE SYSTEMS LTD.',
+         ],
+
+         'EBSCO CANADA' => [
+            'EBSCO Canada',
+            'EBSCO Canada Ltd',
+            'EBSCO CANADA LTD.',
+            'EBSCO CANADA LTEE',
+            'Ebsco Canada Lt̩e',
+            'EBSCO CANADA LT��E',
+            'EBSCO PUBLISHING',
+         ],
+
+         'CISTEL TECHNOLOGY' => [
+            'Cistel',
+            'CISTEL TECHNOLOGY',
+            'Cistel Technology Inc',
+            'CISTEL TECHNOLOGY INC TECSIS CORPORATION IN JOINT VENTURE',
+            'CISTEL TECHNOLOGY INC.',
+         ],
+
+         'CITRIX' => [
+            'Citrix',
+            'CITRIX ONLINE LLC',
+            'CITRIX SYSTEMS INC',
+            'CITRIX SYSTEMS INC.',
+            'CITRIX SYSTEMS, INC.',
+         ],
+
+         'NISHA TECHNOLOGIES' => [
+            'Nisha',
+            'NISHA    Technologie',
+            'NISHA TECHNOLOGIE INC.',
+            'Nisha Technologies',
+            'NISHA TECHNOLOGIES INC',
+            'NISHA TECHNOLOGIES INC.',
+         ],
+
+         'ECLIPSYS SOLUTIONS' => [
+            'ECLIPSYS',
+            'ECLIPSYS SOLUTIONS INC',
+            'ECLIPSYS SOLUTIONS INC.',
+         ],
+
+         'TRANSPOLAR TECHNOLOGY' => [
+            'TRANSPOLAR TECHNOLOGY CORP',
+            'TRANSPOLAR TECHNOLOGY CORP.',
+            'TRANSPOLAR TECHNOLOGY CORPORATION',
+         ],
+
+         'MOTOROLA SOLUTIONS CANADA' => [
+            'MOTOROLA CANADA LTD',
+            'MOTOROLA NATIONAL PARTS',
+            'MOTOROLA SOLUTIONS CANADA INC',
+            'MOTOROLA SOLUTIONS CANADA INC.',
+         ],
+
+         'RESOLVE MARINE GROUP' => [
+            'RESOLVE',
+            'RESOLVE MARINE GROUP INC',
+         ],
+
+         'SALVATION ARMY' => [
+            'SALVATION ARMY',
+            'SALVATION ARMY ARC',
+            'SALVATION ARMY BELKIN HOUSE',
+            'SALVATION ARMY BOOTH CENTRE BRANTFORD',
+            'SALVATION ARMY CENTRE OF HOPE',
+            'SALVATION ARMY CORRECTIONAL &',
+            'SALVATION ARMY CORRECTIONAL AND JUSTICE SERVICES GREENFIELD HOUSE THE',
+            'SALVATION ARMY HARBOUR LIGHT',
+            'SALVATION ARMY HARBOUR LIGHTS CORP',
+            'SALVATION ARMY WAGNER COTTAGE',
+         ],
+
+         'VERITAS TECHNOLOGIES' => [
+            'Veritas',
+            'VERITAS TECHNOLOGIES LLC',
+         ],
+
+         'SIERRA SYSTEMS GROUP' => [
+            'SIERRA SYSTEMS',
+            'SIERRA SYSTEMS GROUP INC',
+            'SIERRA SYSTEMS GROUP INC.',
+         ],
+
+
+    ];
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",
         "symfony/css-selector": "2.8.*|3.0.*",
-        "symfony/dom-crawler": "2.8.*|3.0.*"
+        "symfony/dom-crawler": "2.8.*|3.0.*",
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "264cc46f83b8c9ad8f99d4e538c1f7f2",
+    "content-hash": "34824d034132422ac3d377992edc40cc",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -3223,6 +3223,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "3c2d0a0fe39684ba0c1eb842a6a775d0b938d699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/3c2d0a0fe39684ba0c1eb842a6a775d0b938d699",
+                "reference": "3c2d0a0fe39684ba0c1eb842a6a775d0b938d699",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-09-19T22:47:14+00:00"
         },
         {
             "name": "symfony/css-selector",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <!-- Thanks to: https://matthewdaly.co.uk/blog/2017/03/15/enforcing-a-coding-standard-with-php-codesniffer/ -->
-<!-- If you want to automatically run this on commit, check out WP-Enforcer's pre-commit hook: https://github.com/stevegrunwell/wp-enforcer -->
+<!-- If you want to automatically run this on commit, check out WP-Enforcer's pre-commit hook:
+     https://github.com/stevegrunwell/wp-enforcer (make sure to make it executable!) -->
 <ruleset name="PHP_CodeSniffer">
     <description>The coding standard for our project.</description>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- Thanks to: https://matthewdaly.co.uk/blog/2017/03/15/enforcing-a-coding-standard-with-php-codesniffer/ -->
+<!-- If you want to automatically run this on commit, check out WP-Enforcer's pre-commit hook: https://github.com/stevegrunwell/wp-enforcer -->
+<ruleset name="PHP_CodeSniffer">
+    <description>The coding standard for our project.</description>
+
+    <file>app</file>
+
+    <exclude-pattern>*/migrations/*</exclude-pattern>
+
+    <arg value="np"/>
+
+    <rule ref="PSR2"/>
+</ruleset>


### PR DESCRIPTION
Using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), automatically cleaned up the codebase to match [PSR-2 standards](http://www.php-fig.org/psr/psr-2).

I also included a note in `phpcs.xml` about how to set it up to check your code on every commit; if you need help setting that up, just let me know. It’s a pretty neat feature.